### PR TITLE
fix(@nestjs/typeorm) expose the getRepositoryToken method

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './typeorm.decorators';
 export * from './typeorm.module';
+export * from './typeorm.utils';


### PR DESCRIPTION
closes #5 
  