### PR TITLE
feat(@nestjs/typeorm) add multiple connections support

### DIFF
--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -2,10 +2,9 @@ import { Module, DynamicModule, Global } from '@nestjs/common';
 import {
   ConnectionOptions,
   Connection,
-  createConnection,
-  EntityManager,
+  createConnection
 } from 'typeorm';
-import { getConnectionToken } from "./typeorm.utils";
+import { getConnectionToken, getEntityManagerToken } from "./typeorm.utils";
 
 @Global()
 @Module({})
@@ -16,7 +15,7 @@ export class TypeOrmCoreModule {
       useFactory: async () => await createConnection(options),
     };
     const entityManagerProvider = {
-      provide: EntityManager,
+      provide: getEntityManagerToken(options),
       useFactory: (connection: Connection) => connection.manager,
       inject: [getConnectionToken(options)],
     };

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -5,19 +5,20 @@ import {
   createConnection,
   EntityManager,
 } from 'typeorm';
+import { getConnectionToken } from "./typeorm.utils";
 
 @Global()
 @Module({})
 export class TypeOrmCoreModule {
   static forRoot(options?: ConnectionOptions): DynamicModule {
     const connectionProvider = {
-      provide: Connection,
+      provide: getConnectionToken(options),
       useFactory: async () => await createConnection(options),
     };
     const entityManagerProvider = {
       provide: EntityManager,
       useFactory: (connection: Connection) => connection.manager,
-      inject: [Connection],
+      inject: [getConnectionToken(options)],
     };
     return {
       module: TypeOrmCoreModule,

--- a/lib/typeorm.decorators.ts
+++ b/lib/typeorm.decorators.ts
@@ -1,6 +1,10 @@
 import { Inject } from '@nestjs/common';
+import { Connection, ConnectionOptions } from "typeorm";
 
-import { getRepositoryToken } from './typeorm.utils';
+import { getRepositoryToken, getConnectionToken } from './typeorm.utils';
 
 export const InjectRepository = (entity: Function) =>
   Inject(getRepositoryToken(entity));
+
+export const InjectConnection: ParameterDecorator = (connection: Connection|ConnectionOptions|string) =>
+  Inject(getConnectionToken(connection));

--- a/lib/typeorm.decorators.ts
+++ b/lib/typeorm.decorators.ts
@@ -1,10 +1,13 @@
 import { Inject } from '@nestjs/common';
 import { Connection, ConnectionOptions } from "typeorm";
 
-import { getRepositoryToken, getConnectionToken } from './typeorm.utils';
+import { getRepositoryToken, getConnectionToken, getEntityManagerToken } from './typeorm.utils';
 
 export const InjectRepository = (entity: Function) =>
   Inject(getRepositoryToken(entity));
 
 export const InjectConnection: (connection?: Connection|ConnectionOptions|string) => ParameterDecorator = (connection?: Connection|ConnectionOptions|string) =>
   Inject(getConnectionToken(connection));
+
+export const InjectEntityManager: (connection?: Connection|ConnectionOptions|string) => ParameterDecorator = (connection?: Connection|ConnectionOptions|string) =>
+  Inject(getEntityManagerToken(connection));

--- a/lib/typeorm.decorators.ts
+++ b/lib/typeorm.decorators.ts
@@ -6,5 +6,5 @@ import { getRepositoryToken, getConnectionToken } from './typeorm.utils';
 export const InjectRepository = (entity: Function) =>
   Inject(getRepositoryToken(entity));
 
-export const InjectConnection: ParameterDecorator = (connection: Connection|ConnectionOptions|string) =>
+export const InjectConnection: (connection?: Connection|ConnectionOptions|string) => ParameterDecorator = (connection?: Connection|ConnectionOptions|string) =>
   Inject(getConnectionToken(connection));

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -1,5 +1,5 @@
 import { Module, DynamicModule, Global } from '@nestjs/common';
-import { ConnectionOptions } from 'typeorm';
+import { Connection, ConnectionOptions } from 'typeorm';
 
 import { createTypeOrmProviders } from './typeorm.providers';
 import { TypeOrmCoreModule } from './typeorm-core.module';
@@ -14,8 +14,8 @@ export class TypeOrmModule {
     };
   }
 
-  static forFeature(entities: Function[] = []): DynamicModule {
-    const providers = createTypeOrmProviders(entities);
+  static forFeature(entities: Function[] = [], connection: Connection|ConnectionOptions|string = 'default'): DynamicModule {
+    const providers = createTypeOrmProviders(entities, connection);
     return {
       module: TypeOrmModule,
       components: providers,

--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -1,8 +1,8 @@
 import { ConnectionOptions, Connection } from 'typeorm';
 
-import { getRepositoryToken } from './typeorm.utils';
+import { getConnectionToken, getRepositoryToken } from './typeorm.utils';
 
-export function createTypeOrmProviders(entities?: Function[]) {
+export function createTypeOrmProviders(entities?: Function[], connection?: Connection|ConnectionOptions|string) {
   const getRepository = (connection: Connection, entity) =>
     connection.options.type === 'mongodb'
       ? connection.getMongoRepository(entity)
@@ -12,7 +12,8 @@ export function createTypeOrmProviders(entities?: Function[]) {
     provide: getRepositoryToken(entity),
     useFactory: (connection: Connection) =>
       getRepository(connection, entity) as any,
-    inject: [Connection],
+    inject: [getConnectionToken(connection)],
   }));
+
   return [...repositories];
 }

--- a/lib/typeorm.utils.ts
+++ b/lib/typeorm.utils.ts
@@ -1,3 +1,17 @@
+import { Connection, ConnectionOptions } from 'typeorm';
+
 export function getRepositoryToken(entity: Function) {
   return `${entity.name}Repository`;
+}
+
+/**
+ * This function returns a injection token for the given Connection, ConnectionOptions or connection name.
+ * @param {Connection | ConnectionOptions | string} [connection='default'] This optional parameter is either
+ * a Connection, or a ConnectionOptions or a string.
+ * @returns {string | Function} The Connection injection token.
+ */
+export function getConnectionToken(connection: Connection|ConnectionOptions|string = 'default'): string|Function {
+  return 'string' === typeof connection ? `${connection}Connection`
+    : 'default' === connection.name ? Connection
+    : `${connection.name}Connection`;
 }

--- a/lib/typeorm.utils.ts
+++ b/lib/typeorm.utils.ts
@@ -1,11 +1,11 @@
-import { Connection, ConnectionOptions } from 'typeorm';
+import { Connection, ConnectionOptions, EntityManager } from 'typeorm';
 
 export function getRepositoryToken(entity: Function) {
   return `${entity.name}Repository`;
 }
 
 /**
- * This function returns a injection token for the given Connection, ConnectionOptions or connection name.
+ * This function returns a Connection injection token for the given Connection, ConnectionOptions or connection name.
  * @param {Connection | ConnectionOptions | string} [connection='default'] This optional parameter is either
  * a Connection, or a ConnectionOptions or a string.
  * @returns {string | Function} The Connection injection token.
@@ -15,4 +15,17 @@ export function getConnectionToken(connection: Connection|ConnectionOptions|stri
     : 'string' === typeof connection ? `${connection}Connection`
     : 'default' === connection.name || !connection.name ? Connection
     : `${connection.name}Connection`;
+}
+
+/**
+ * This function returns an EntityManager injection token for the given Connection, ConnectionOptions or connection name.
+ * @param {Connection | ConnectionOptions | string} [connection='default'] This optional parameter is either
+ * a Connection, or a ConnectionOptions or a string.
+ * @returns {string | Function} The EntityManager injection token.
+ */
+export function getEntityManagerToken(connection: Connection|ConnectionOptions|string = 'default'): string|Function {
+  return 'default' === connection ? EntityManager
+    : 'string' === typeof connection ? `${connection}EntityManager`
+      : 'default' === connection.name || !connection.name ? EntityManager
+        : `${connection.name}EntityManager`;
 }

--- a/lib/typeorm.utils.ts
+++ b/lib/typeorm.utils.ts
@@ -11,7 +11,8 @@ export function getRepositoryToken(entity: Function) {
  * @returns {string | Function} The Connection injection token.
  */
 export function getConnectionToken(connection: Connection|ConnectionOptions|string = 'default'): string|Function {
-  return 'string' === typeof connection ? `${connection}Connection`
-    : 'default' === connection.name ? Connection
+  return 'default' === connection ? Connection
+    : 'string' === typeof connection ? `${connection}Connection`
+    : 'default' === connection.name || !connection.name ? Connection
     : `${connection.name}Connection`;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/typeorm",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Nest - modern, fast, powerful node.js web framework (@typeorm)",
   "author": "Kamil Mysliwiec",
   "license": "MIT",


### PR DESCRIPTION
For the needs of one of my projects, I have to handle connections to different databases. This was not possible with the `nestjs/typeorm` module : 
- The `TypeOrmModule.forRoot` function only takes one connection options object, thus only creates one connection to one database
- The `Connection` created by the `TypeOrmModule.forRoot({... connection options ...})` would get `Connection` as an injection token, no matter what. This means that multiple calls to `forRoot` wasn't a solution

This PR adds the support for multiple connections and there is no breaking change ;)

There is a usage example:
```js
@Module({
  imports: [
    TypeOrmModule.forRoot({
      type: 'postgres',
      name: 'animalsConnection', // pay attention to the connection name
      host:  'database_host_01',
      port: 5432,
      username: 'user',
      password: 'password',
      database: 'db',
      entities: [ Animal ],
      synchronize: true
    }),
    TypeOrmModule.forRoot({
      type: 'postgres',
      name: 'projectsConnection', // pay attention to the connection name
      host:  'database_host_02',
      port: 5432,
      username: 'user',
      password: 'password',
      database: 'db',
      entities: [ Project ],
      synchronize: true
    }),
    TypeOrmModule.forRoot({
      type: 'postgres',
      // Not defining any name means this is the default connection.
      // If you only use one database, there is no need to name the connection.
      host:  'database_host_03',
      port: 5432,
      username: 'user',
      password: 'password',
      database: 'db',
      entities: [ User ],
      synchronize: true
    }),
    // These both entities are each stored in a different database.
    // The main feature of this PR is being able to define which Connection 
    // should be used to get the Repository
    TypeOrmModule.forFeature([ Animal ], 'animalsConnection'),
    TypeOrmModule.forFeature([ Project ], 'projectsConnection'),
    // Those who only rely on a single database won't be bothered at all.
    TypeOrmModule.forFeature([ User ])
  ]
})
export class ApplicationModule {}
```

I'm feeling like this is a really important feature. I think my implementation is pretty neat but you might not agree with me so feel free to share you thoughts.