### PR TITLE
Add support for custom repositories

### DIFF
--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions, Connection } from 'typeorm';
+import { Connection, Repository } from 'typeorm';
 
 import { getRepositoryToken } from './typeorm.utils';
 
@@ -8,10 +8,19 @@ export function createTypeOrmProviders(entities?: Function[]) {
       ? connection.getMongoRepository(entity)
       : connection.getRepository(entity);
 
-  const repositories = (entities || []).map(entity => ({
+  const getCustomRepository = (connection: Connection, entity) =>
+    connection.getCustomRepository(entity);
+
+  const repositories = (entities || []).map((entity) => ({
     provide: getRepositoryToken(entity),
-    useFactory: (connection: Connection) =>
-      getRepository(connection, entity) as any,
+    useFactory: (connection: Connection) => {
+
+      if (entity.prototype instanceof Repository) {
+        return getCustomRepository(connection, entity) as any;
+      }
+
+      return getRepository(connection, entity) as any;
+    },
     inject: [Connection],
   }));
   return [...repositories];


### PR DESCRIPTION
http://typeorm.io/#/custom-repository

Currently type orm fails as it tries to load custom repository as an Entity.
> No repository for "UserRepository" was found. Looks like this entity is not registered in current "default" connection?

We should check if "entity" is extending `Repository`, if it is, then we know this is custom repository and load it `getCustomRepository`. 

This way we can do:
```ts
...
imports: [
    // User is entity, UserRepository is custom repository
    TypeOrmModule.forFeature([User, UserRepository]), 
]
...
```

About mongo support. I'm not sure if it supports custom repositories at all. I can't find anything in the documentation.

EDIT: Mongo supports custom repositories as well. No changes needed.