### PR TITLE
added `http://` to make link to `typeorm.io` work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Description
 
-This's a [TypeORM](typeorm.io) module for [Nest](https://github.com/nestjs/nest).
+This's a [TypeORM](http://typeorm.io) module for [Nest](https://github.com/nestjs/nest).
 
 ## Installation
 


### PR DESCRIPTION
the typeorm link didnt work since it was missing the `http://` prefix and instead redirected you to an 404 page.