### PR TITLE
feat(connection): added multiple connection attempts before throwing …

### DIFF
--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -5,6 +5,7 @@ import {
   createConnection,
   EntityManager,
 } from 'typeorm';
+import { attemptConnectionCreation } from './typeorm.utils';
 
 @Global()
 @Module({})
@@ -12,7 +13,7 @@ export class TypeOrmCoreModule {
   static forRoot(options?: ConnectionOptions): DynamicModule {
     const connectionProvider = {
       provide: Connection,
-      useFactory: async () => await createConnection(options),
+      useFactory: async () => await attemptConnectionCreation(createConnection, options),
     };
     const entityManagerProvider = {
       provide: EntityManager,

--- a/lib/typeorm.utils.ts
+++ b/lib/typeorm.utils.ts
@@ -1,3 +1,33 @@
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('TypeOrm');
+
 export function getRepositoryToken(entity: Function) {
   return `${entity.name}Repository`;
+}
+
+export async function attemptConnectionCreation(connectMethod, options, attempt?) {
+  const maxAttempts       = 5;
+  const connectionAttempt = attempt || 1;
+
+  try {
+    return await connectMethod(options);
+  } catch (err) {
+    logger.error(`Connection Attempt #${connectionAttempt} failed. ${err.toString()}`);
+
+    if (connectionAttempt >= maxAttempts) {
+      throw err;
+    }
+
+    await sleep(getIdleTime(connectionAttempt));
+    return attemptConnectionCreation(connectMethod, options, connectionAttempt + 1);
+  }
+}
+
+function getIdleTime(attempt) {
+  return 1000 * attempt;
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
The Issues this pull request is trying to tackle is that a nestjs application that uses typeorm will instantly fail, if it is not able to connect to the specified backend.

I use nestjs with typeorm in a project of mine and encountered this issue when I try to dockerize the application. The nest application itself lives in another container than the mysql it should connect to. 

When fireing up my docker-compose, the nest-container will wait for the mysql-container to be running, but not until the ports are open and everything is setup, so the first connection attempt is doomed to fail in 95% of the time.

The [docker documentation about the start order](https://docs.docker.com/compose/startup-order/) states the following: 

> The problem of waiting for a database (for example) to be ready is really just a subset of a much larger problem of distributed systems. In production, your database could become unavailable or move hosts at any time. **Your application needs to be resilient to these types of failures**.

> To handle this, **design your application to attempt to re-establish a connection** to the database after a failure. If the application retries the connection, it can eventually connect to the database.

This pull request probably needs to be tweaked a bit to match your quality criterias, so if you have ideas for improvement please let me know.