### PR TITLE
EntitySubscriberAbstract is an abstract class which auto inject the e…

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './typeorm.decorators';
+export * from './typeorm.subscribers';
 export * from './typeorm.module';
 export * from './typeorm.utils';

--- a/lib/typeorm.subscribers.ts
+++ b/lib/typeorm.subscribers.ts
@@ -1,0 +1,17 @@
+import { Repository } from "typeorm";
+
+export abstract class EntitySubscriberAbstract {
+    /**
+     * @description Constructor
+     *
+     * @param {Repository<any>} repository The repository where the Subscriber will be injected
+     */
+    protected constructor(repository: Repository<any>) {
+        Object.assign(
+            repository.manager.connection,
+            {
+                subscribers: [].concat(...repository.manager.connection.subscribers).concat([this]),
+            }
+        );
+    }
+}


### PR DESCRIPTION
Hello,

Because, at some point, I needed a TypeORM event subscriber which depends on other NestJS services and I didn't found any solution, yet, I created this abstract class which can be extended and inject the extender to the TypeORM connection subscribers.
The inject is inspired by the way how TypeORM build the subscribers list in `buildMetadatas`:

	// create subscribers instances if they are not disallowed from high-level (for example they can disallowed from migrations run process)
	const subscribers = connectionMetadataBuilder.buildSubscribers(this.options.subscribers || []);
	Object.assign(this, { subscribers: subscribers });

In the same way, the abstract class inject it self in the connection `subscribers` property.

Hope this will be useful for other developers and will be merged in the repo.
