### PR TITLE
feat: add @InjectedEventSubscriber to support injection from nestjs

### DIFF
--- a/lib/typeorm.decorators.ts
+++ b/lib/typeorm.decorators.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { Connection, ConnectionOptions } from 'typeorm';
 
-const AUTO_DELCARED_DEPS_METADATA = 'design:paramtypes';
+const AUTO_DECLARED_DEPS_METADATA = 'design:paramtypes';
 const SELF_DECLARED_DEPS_METADATA = 'self:paramtypes';
 
 import {
@@ -37,17 +37,16 @@ export function InjectedEventSubscriber(
       Object.assign(conn, {
         subscribers: [].concat(conn.subscribers).concat([instance]),
       });
-      console.log(f);
       return instance;
     };
-
+    Object.defineProperty(f, 'name', { value: original.name });
     f.prototype = original.prototype;
 
-    // Apply metadata from design type for NestJS auto-injection, and add the default Connection
+    // Apply metadata from design type for NestJS auto-injection, and add the default connection
     const argsMetadata =
-      Reflect.getMetadata(AUTO_DELCARED_DEPS_METADATA, target) || [];
+      Reflect.getMetadata(AUTO_DECLARED_DEPS_METADATA, target) || [];
     const newArgsMetadata = [Connection, ...argsMetadata];
-    Reflect.defineMetadata(AUTO_DELCARED_DEPS_METADATA, newArgsMetadata, f);
+    Reflect.defineMetadata(AUTO_DECLARED_DEPS_METADATA, newArgsMetadata, f);
 
     // Apply metadata from Token @Inject, and append Connection request as parameter to the decorator
     const manualMetadata =

--- a/lib/typeorm.decorators.ts
+++ b/lib/typeorm.decorators.ts
@@ -1,6 +1,9 @@
 import { Inject } from '@nestjs/common';
 import { Connection, ConnectionOptions } from 'typeorm';
 
+const AUTO_DELCARED_DEPS_METADATA = 'design:paramtypes';
+const SELF_DECLARED_DEPS_METADATA = 'self:paramtypes';
+
 import {
   getRepositoryToken,
   getConnectionToken,
@@ -21,3 +24,48 @@ export const InjectEntityManager: (
 ) => ParameterDecorator = (
   connection?: Connection | ConnectionOptions | string,
 ) => Inject(getEntityManagerToken(connection));
+
+export function InjectedEventSubscriber(
+  connection?: Connection | ConnectionOptions | string,
+): ClassDecorator {
+  return (target: any) => {
+    const original = target;
+
+    const f: any = function(...args) {
+      const conn = args[0] as Connection;
+      let instance = new original(...args.slice(1));
+      Object.assign(conn, {
+        subscribers: [].concat(conn.subscribers).concat([instance]),
+      });
+      console.log(f);
+      return instance;
+    };
+
+    f.prototype = original.prototype;
+
+    // Apply metadata from design type for NestJS auto-injection, and add the default Connection
+    const argsMetadata =
+      Reflect.getMetadata(AUTO_DELCARED_DEPS_METADATA, target) || [];
+    const newArgsMetadata = [Connection, ...argsMetadata];
+    Reflect.defineMetadata(AUTO_DELCARED_DEPS_METADATA, newArgsMetadata, f);
+
+    // Apply metadata from Token @Inject, and append Connection request as parameter to the decorator
+    const manualMetadata =
+      Reflect.getMetadata(SELF_DECLARED_DEPS_METADATA, target) || [];
+    const newManualMetatadata = [
+      ...manualMetadata.map((meta: any) =>
+        Object.assign({}, meta, { index: meta.index + 1 }),
+      ),
+    ];
+    if (connection) {
+      newManualMetatadata.push({
+        index: 0,
+        param: getConnectionToken(connection),
+      });
+    }
+    Reflect.defineMetadata(SELF_DECLARED_DEPS_METADATA, newManualMetatadata, f);
+
+    // return new constructor (will override original)
+    return f;
+  };
+}


### PR DESCRIPTION
Hey!

I saw Pull request #23 and I had exactly the same use case.
I have therefore implemented a new decorator, as proposed in the above PR.

## Example usage

```ts
import { Injectable } from '@nestjs/common';
import { InjectedEventSubscriber } from '@nestjs/typeorm';

@Injectable('default')
@InjectedEventSubscriber()
export class CompanySubscriber implements EntitySubscriberInterface<Company> {
  constructor(
    private companyService: CompanyService,
    @Inject('SomethingElse') something: Else,
  ) {
  }
...
  afterUpdate(event: UpdateEvent<Company>) {
    console.log(`BEFORE POST INSERTED: `, this.companyService.doSomethingElse(event.entity));
  }
}
```

And the Subscriber needs to be registered as a provider in NestJS
```
 providers: [
    ...
     CompanySubscriber,
    CompanyService,
 ....
  ],
```


## How it works

The class will fake the constructor with a new one that requires the "Connection" (By default the default connection is passed, unless specified as a parameter to the decorator).

To do this, the metadata of the "fake constructor" are set with the metadata of the normal constructor + the metadata required to inject the connection.

When the subscriber is created, the subscriber is added to the subscribers from the connection.


Thanks