### PR TITLE
feature: log TypeORM error stack when connection fails

### DIFF
--- a/lib/typeorm.utils.ts
+++ b/lib/typeorm.utils.ts
@@ -55,7 +55,7 @@ export function handleRetry(
             Logger.error(
               `Unable to connect to the database. Retrying (${errorCount +
                 1})...`,
-              '',
+              error.stack,
               'TypeOrmModule',
             );
             if (errorCount + 1 >= retryAttempts) {


### PR DESCRIPTION
Currently the same error message is displayed regardless of the underlying
cause of failure . This change also outputs the Error.stack string to the
logger.

Fixes #30

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
(no tests in this project)
- [ ] Docs have been added / updated (for bug fixes / features)
(no specific docs in this project


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When attempting to connect using the `handleRetry` operator, all error information from TypeORM is swallowed and a generic "Unable to connect to the database" message is displayed.

Any number of things can cause the TypeORM `createConnection` function to fail - invalid credentials, incorrectly defined entities, database unreachable etc. Without this information the developer is left guessing.

Issue Number: #30


## What is the new behavior?
The stack trace of the error object is also passed to the logger (rather than an empty string). This gives enough information to the developer to know what the particular failure was.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```
