### PR TITLE
feature: options factory for multiple connections

### DIFF
--- a/lib/interfaces/typeorm-options.interface.ts
+++ b/lib/interfaces/typeorm-options.interface.ts
@@ -9,7 +9,9 @@ export type TypeOrmModuleOptions = {
 } & Partial<ConnectionOptions>;
 
 export interface TypeOrmOptionsFactory {
-  createTypeOrmOptions(): Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions;
+  createTypeOrmOptions(
+    name?: string,
+  ): Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions;
 }
 
 export interface TypeOrmModuleAsyncOptions

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -135,7 +135,7 @@ export class TypeOrmCoreModule implements OnModuleDestroy {
     return {
       provide: TYPEORM_MODULE_OPTIONS,
       useFactory: async (optionsFactory: TypeOrmOptionsFactory) =>
-        await optionsFactory.createTypeOrmOptions(),
+        await optionsFactory.createTypeOrmOptions(options.name),
       inject: [options.useClass || options.useExisting],
     };
   }


### PR DESCRIPTION
Pass connection name to the options factory, so different options can be
returned for different connections.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently TypeOrmModule can use options factory to retrieve connection options, for example, from some configuration service, but no arguments are passed to `createTypeOrmOptions()` medhod, so this feature is unused in a case of multiple database connections.

Issue Number: N/A


## What is the new behavior?
optional `name` parameter is passed to the options factory, so developers can use it for selecting options for particular connection name.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
