### PR TITLE
getRepositoryToken returns correct tokens for custom repositories

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -1,11 +1,31 @@
 import { Logger } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { delay, retryWhen, scan } from 'rxjs/operators';
-import { Connection, ConnectionOptions, EntityManager } from 'typeorm';
+import { Connection, ConnectionOptions, EntityManager, Repository, AbstractRepository } from 'typeorm';
 import * as uuid from 'uuid/v4';
 
+/**
+ * This function generates an injection token for an Entity or Repository
+ * @param {Function} This parameter can either be an Entity or Repository 
+ * @returns {string} The Entity | Repository injection token
+ */
 export function getRepositoryToken(entity: Function) {
+  if (
+    entity.prototype instanceof Repository ||
+    entity.prototype instanceof AbstractRepository
+  ) {
+    return getCustomRepositoryToken(entity);
+  }
   return `${entity.name}Repository`;
+}
+
+/**
+ * This function generates an injection token for an Entity or Repository
+ * @param {Function} This parameter can either be an Entity or Repository 
+ * @returns {string} The Repository injection token
+ */
+export function getCustomRepositoryToken(repository: Function) {
+  return repository.name;
 }
 
 /**


### PR DESCRIPTION
## PR Type
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: [#55](https://github.com/nestjs/typeorm/issues/55)


## What is the new behavior?
`getRpositoryToken(UserRepository)` now returns `'UserRepository'` instead of `'UserRepositoryRepository'`.

`getRpositoryToken(User)` still returns `'UserRepository'`.

#### Added feature
A new utility function was created to generate injection tokens specifically for custom repositories.
```
getCustomRepositoryToken(repository: Function): string
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If you are using a [TypeORM Custom Repository](http://typeorm.io/#/custom-repository) and are relying on the `@InjectRepository()` decorator to inject your custom repository you will have to change how you generate injection tokens for your custom providers.

Using UserRepository as an example:
```
@EntityRepository(User)
export class UserRepository extends Repository<User> {}

@Injectable()
export class UserService {

  constructor(
    @InjectRepository(UserRepository)
    private readonly userRepository: UserRepository,
  ) {}
}
```

If you were using a hard coded injection token in your custom provider you would do the following:
```
// The Original Way
{
  provide: 'UserRepositoryRepository', // The trailing `Repository` is a symptom of a bug
  userClass: UserRepository,
}

// The Required Change
{
  provide: 'UserRepository', // Remove the trailing 'Repository'
  useClass: UserRepository,
}

// The Best Way
{
  provide: getRepositoryToken(UserRepository), 
  useClass: UserRepository,
}
```
`getRepositoryToken(UserRepository)` now returns returns 'UserRepository' instead of 'UserRepositoryRepository'.
```
## Other information