### PR TITLE
support @InjectRepository with multi connection

### DIFF
--- a/lib/common/typeorm.decorators.ts
+++ b/lib/common/typeorm.decorators.ts
@@ -6,8 +6,10 @@ import {
   getRepositoryToken,
 } from './typeorm.utils';
 
-export const InjectRepository = (entity: Function) =>
-  Inject(getRepositoryToken(entity));
+export const InjectRepository = (
+  entity: Function,
+  connection: string = 'default',
+) => Inject(getRepositoryToken(entity, connection));
 
 export const InjectConnection: (
   connection?: Connection | ConnectionOptions | string,

--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -15,16 +15,20 @@ const logger = new Logger('TypeOrmModule');
 /**
  * This function generates an injection token for an Entity or Repository
  * @param {Function} This parameter can either be an Entity or Repository
+ * @param {string} [connection='default'] Connection name
  * @returns {string} The Entity | Repository injection token
  */
-export function getRepositoryToken(entity: Function) {
+export function getRepositoryToken(
+  entity: Function,
+  connection: string = 'default',
+) {
   if (
     entity.prototype instanceof Repository ||
     entity.prototype instanceof AbstractRepository
   ) {
-    return getCustomRepositoryToken(entity);
+    return `${connection}_${getCustomRepositoryToken(entity)}`;
   }
-  return `${entity.name}Repository`;
+  return `${connection}_${entity.name}Repository`;
 }
 
 /**
@@ -48,10 +52,10 @@ export function getConnectionToken(
   return 'default' === connection
     ? Connection
     : 'string' === typeof connection
-      ? `${connection}Connection`
-      : 'default' === connection.name || !connection.name
-        ? Connection
-        : `${connection.name}Connection`;
+    ? `${connection}Connection`
+    : 'default' === connection.name || !connection.name
+    ? Connection
+    : `${connection.name}Connection`;
 }
 
 /**
@@ -66,10 +70,10 @@ export function getEntityManagerToken(
   return 'default' === connection
     ? EntityManager
     : 'string' === typeof connection
-      ? `${connection}EntityManager`
-      : 'default' === connection.name || !connection.name
-        ? EntityManager
-        : `${connection.name}EntityManager`;
+    ? `${connection}EntityManager`
+    : 'default' === connection.name || !connection.name
+    ? EntityManager
+    : `${connection.name}EntityManager`;
 }
 
 export function handleRetry(

--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -27,7 +27,7 @@ export function createTypeOrmProviders(
     connection.getCustomRepository(entity);
 
   const repositories = (entities || []).map(entity => ({
-    provide: getRepositoryToken(entity),
+    provide: getRepositoryToken(entity, connection as string),
     useFactory: (connection: Connection) => {
       if (entity.prototype instanceof Repository) {
         return getCustomRepository(connection, entity) as any;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #68


## What is the new behavior?

Add an optional second parameter on `@InjectRepository` to specify the server name. Default connection name will be `default` if not provide.
```ts
@InjectRepository(User, 'custom_server_name') private readonly user: Repository<User>
@InjectRepository(UserRepository, 'custom_server_name') private readonly userRepository: UserRepository
```
**NOTE:** Another slightly changes, if you are define a connection name eg: `my_server` in your module, then when you inject your repository you must provide `@InjectRepository` a second parameter or it will not work because `@InjectRepository` is used `default` as a default connection name
```ts
// application.module.ts
@Module({
  imports: [
    TypeOrmModule.forRootAsync({ useClass: TypeOrmConfigService, name: 'my_server' }),
    TypeOrmModule.forFeature([User], 'my_server')
  ]
})
export class ApplicationModule {}
```

```ts
// my-custom.service.ts
export class MyCustomService{
  constructor(
    @InjectRepository(User) private readonly user: Repository<User>, // <-- Not working
    @InjectRepository(User, 'my_server') private readonly user: Repository<User> // <-- Working
  ) {}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Kind of (describe on NOTE above)
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information