### PR TITLE
feature(): Throw error when try import `TypeOrmModule`

### DIFF
--- a/lib/exceptions/wrong-module-import.exception.ts
+++ b/lib/exceptions/wrong-module-import.exception.ts
@@ -1,0 +1,8 @@
+export class WrongModuleImportException extends Error {
+  constructor() {
+    super(
+      'Import the TypeOrmModule by calling either TypeOrmModule.forRoot(), TypeOrmModule.forRootAsync(),' +
+        ' TypeOrmModule.forFeature() inside the imports-array.',
+    );
+  }
+}

--- a/lib/typeorm.constants.ts
+++ b/lib/typeorm.constants.ts
@@ -1,3 +1,4 @@
 export const TYPEORM_MODULE_OPTIONS = 'TypeOrmModuleOptions';
 export const TYPEORM_MODULE_ID = 'TypeOrmModuleId';
 export const DEFAULT_CONNECTION_NAME = 'default';
+export const WRONG_MODULE_IMPORT = 'TypeOrmModule:WRONG_MODULE_IMPORT';

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -5,10 +5,23 @@ import {
   TypeOrmModuleOptions,
 } from './interfaces/typeorm-options.interface';
 import { TypeOrmCoreModule } from './typeorm-core.module';
-import { DEFAULT_CONNECTION_NAME } from './typeorm.constants';
+import {
+  DEFAULT_CONNECTION_NAME,
+  WRONG_MODULE_IMPORT,
+} from './typeorm.constants';
 import { createTypeOrmProviders } from './typeorm.providers';
+import { WrongModuleImportException } from './exceptions/wrong-module-import.exception';
 
-@Module({})
+@Module({
+  providers: [
+    {
+      provide: WRONG_MODULE_IMPORT,
+      useFactory: () => {
+        throw new WrongModuleImportException();
+      },
+    },
+  ],
+})
 export class TypeOrmModule {
   static forRoot(options?: TypeOrmModuleOptions): DynamicModule {
     return {

--- a/tests/e2e/typeorm.spec.ts
+++ b/tests/e2e/typeorm.spec.ts
@@ -3,6 +3,8 @@ import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { ApplicationModule } from '../src/app.module';
 import { Server } from 'http';
+import { TypeOrmModule } from '../../lib';
+import { WrongModuleImportException } from '../../lib/exceptions/wrong-module-import.exception';
 
 describe('TypeOrm', () => {
   let server: Server;
@@ -22,6 +24,18 @@ describe('TypeOrm', () => {
     return request(server)
       .post('/photo')
       .expect(201, { name: 'Nest', description: 'Is great!', views: 6000 });
+  });
+
+  it('should throw an exception when the wrong TypeOrmModule is initialized', async () => {
+    const module = Test.createTestingModule({
+      imports: [TypeOrmModule],
+    });
+
+    try {
+      await module.compile();
+    } catch (err) {
+      expect(err instanceof WrongModuleImportException).toBe(true);
+    }
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently if the user imports `TypeOrmModule` nothing happens. 

## What is the new behavior?
The user should be prompted to use `TypeOrmModule.forRoot[Async]()` or `TypeOrmModule.forFeature()` instead.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
