### PR TITLE
feat(): Add support for typeorm@0.3.0 literal repositories #383

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -16,6 +16,21 @@ import { DEFAULT_CONNECTION_NAME } from '../typeorm.constants';
 const logger = new Logger('TypeOrmModule');
 
 /**
+ * TypeORM 0.3.0 possible literal repository types.
+ *
+ * @see https://github.com/typeorm/typeorm/blob/b177e230a6fcb11f1eb71d4d431d0297436b7f6f/src/repository/Repository.ts#L29
+ */
+const typeormLiteralRepositoryTypes = [
+  'Repository',
+  'MongoRepository',
+  'TreeRepository',
+];
+
+export function isLiteralRepository(value: any) {
+  return typeormLiteralRepositoryTypes.includes(value.typeof);
+}
+
+/**
  * This function generates an injection token for an Entity or Repository
  * @param {Function} This parameter can either be an Entity or Repository
  * @param {string} [connection='default'] Connection name
@@ -29,13 +44,37 @@ export function getRepositoryToken(
     throw new CircularDependencyException('@InjectRepository()');
   }
   const connectionPrefix = getConnectionPrefix(connection);
+  const isTypeormNext = typeof Repository !== 'function';
+  let name;
+
   if (
-    entity.prototype instanceof Repository ||
-    entity.prototype instanceof AbstractRepository
+    !isTypeormNext &&
+    (entity.prototype instanceof Repository ||
+      entity.prototype instanceof AbstractRepository)
   ) {
+    // TypeORM pre-0.3.0 repository class
     return `${connectionPrefix}${getCustomRepositoryToken(entity)}`;
+  } else if (isTypeormNext && isLiteralRepository(entity)) {
+    // TypeORM 0.3.0+ literal repository
+    const repository: { target: Function | string } = entity as any;
+    name =
+      typeof repository.target === 'string'
+        ? repository.target
+        : repository.target.name;
+  } else if (isTypeormNext) {
+    /**
+     * TypeORM 0.3.0+ entity can be different types - function, string or
+     * literal with `name` property.
+     *
+     * @see https://github.com/typeorm/typeorm/blob/b177e230a6fcb11f1eb71d4d431d0297436b7f6f/src/common/EntityTarget.ts#L7
+     */
+    name = typeof entity === 'string' ? entity : entity.name;
+  } else {
+    // TypeORM pre-0.3.0 entity class
+    name = entity.name;
   }
-  return `${connectionPrefix}${entity.name}Repository`;
+
+  return `${connectionPrefix}${name}Repository`;
 }
 
 /**
@@ -113,12 +152,13 @@ export function handleRetry(
 ): <T>(source: Observable<T>) => Observable<T> {
   return <T>(source: Observable<T>) =>
     source.pipe(
-      retryWhen(e =>
+      retryWhen((e) =>
         e.pipe(
           scan((errorCount, error: Error) => {
             logger.error(
-              `Unable to connect to the database. Retrying (${errorCount +
-                1})...`,
+              `Unable to connect to the database. Retrying (${
+                errorCount + 1
+              })...`,
               error.stack,
             );
             if (errorCount + 1 >= retryAttempts) {

--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -11,12 +11,13 @@ export function createTypeOrmProviders(
   entities?: Function[],
   connection?: Connection | ConnectionOptions | string,
 ): Provider[] {
-  return (entities || []).map(entity => ({
+  return (entities || []).map((entity) => ({
     provide: getRepositoryToken(entity, connection),
     useFactory: (connection: Connection) => {
       if (
-        entity.prototype instanceof Repository ||
-        entity.prototype instanceof AbstractRepository
+        typeof Repository === 'function' &&
+        (entity.prototype instanceof Repository ||
+          entity.prototype instanceof AbstractRepository)
       ) {
         return connection.getCustomRepository(entity);
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/typeorm/issues/383


## What is the new behavior?
Check if `Repository` is a function to determine if `typeorm@0.3.0` is being used and if so then use the literal repository object to generate repository injection token.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Tests are passing for current `typeorm@0.2.24` but failing for `typeorm@0.3.0` due to `Repository` no longer being a function. The custom repository also needs to be refactored: https://github.com/nestjs/typeorm/blob/master/tests/src/photo/photo.repository.ts#L5 