### PR TITLE
feat(): add support for entity schema

### DIFF
--- a/lib/common/typeorm.decorators.ts
+++ b/lib/common/typeorm.decorators.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { Connection, ConnectionOptions } from 'typeorm';
+import { EntityClassOrSchema } from '../interfaces/entity-class-or-schema.type';
 import { DEFAULT_CONNECTION_NAME } from '../typeorm.constants';
 import {
   getConnectionToken,
@@ -8,7 +9,7 @@ import {
 } from './typeorm.utils';
 
 export const InjectRepository = (
-  entity: Function,
+  entity: EntityClassOrSchema,
   connection: string = DEFAULT_CONNECTION_NAME,
 ) => Inject(getRepositoryToken(entity, connection));
 

--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -6,23 +6,25 @@ import {
   Connection,
   ConnectionOptions,
   EntityManager,
+  EntitySchema,
   Repository,
 } from 'typeorm';
 import { isNullOrUndefined } from 'util';
 import { v4 as uuid } from 'uuid';
 import { CircularDependencyException } from '../exceptions/circular-dependency.exception';
+import { EntityClassOrSchema } from '../interfaces/entity-class-or-schema.type';
 import { DEFAULT_CONNECTION_NAME } from '../typeorm.constants';
 
 const logger = new Logger('TypeOrmModule');
 
 /**
  * This function generates an injection token for an Entity or Repository
- * @param {Function} This parameter can either be an Entity or Repository
+ * @param {EntityClassOrSchema} entity parameter can either be an Entity or Repository
  * @param {string} [connection='default'] Connection name
  * @returns {string} The Entity | Repository injection token
  */
 export function getRepositoryToken(
-  entity: Function,
+  entity: EntityClassOrSchema,
   connection: Connection | ConnectionOptions | string = DEFAULT_CONNECTION_NAME,
 ) {
   if (isNullOrUndefined(entity)) {
@@ -30,10 +32,17 @@ export function getRepositoryToken(
   }
   const connectionPrefix = getConnectionPrefix(connection);
   if (
-    entity.prototype instanceof Repository ||
-    entity.prototype instanceof AbstractRepository
+    entity instanceof Function &&
+    (entity.prototype instanceof Repository ||
+      entity.prototype instanceof AbstractRepository)
   ) {
     return `${connectionPrefix}${getCustomRepositoryToken(entity)}`;
+  }
+
+  if (entity instanceof EntitySchema) {
+    return `${connectionPrefix}${
+      entity.options.target ? entity.options.target.name : entity.options.name
+    }Repository`;
   }
   return `${connectionPrefix}${entity.name}Repository`;
 }
@@ -114,7 +123,7 @@ export function handleRetry(
 ): <T>(source: Observable<T>) => Observable<T> {
   return <T>(source: Observable<T>) =>
     source.pipe(
-      retryWhen(e =>
+      retryWhen((e) =>
         e.pipe(
           scan((errorCount, error: Error) => {
             const connectionInfo =
@@ -122,8 +131,9 @@ export function handleRetry(
                 ? ''
                 : ` (${connectionName})`;
             logger.error(
-              `Unable to connect to the database${connectionInfo}. Retrying (${errorCount +
-                1})...`,
+              `Unable to connect to the database${connectionInfo}. Retrying (${
+                errorCount + 1
+              })...`,
               error.stack,
             );
             if (errorCount + 1 >= retryAttempts) {

--- a/lib/entities-metadata.storage.ts
+++ b/lib/entities-metadata.storage.ts
@@ -1,13 +1,14 @@
 import { Connection, ConnectionOptions } from 'typeorm';
+import { EntityClassOrSchema } from './interfaces/entity-class-or-schema.type';
 
 type ConnectionToken = Connection | ConnectionOptions | string;
 
 export class EntitiesMetadataStorage {
-  private static readonly storage = new Map<string, Function[]>();
+  private static readonly storage = new Map<string, EntityClassOrSchema[]>();
 
   static addEntitiesByConnection(
     connection: ConnectionToken,
-    entities: Function[],
+    entities: EntityClassOrSchema[],
   ) {
     const connectionToken =
       typeof connection === 'string' ? connection : connection.name;
@@ -20,7 +21,7 @@ export class EntitiesMetadataStorage {
       collection = [];
       this.storage.set(connectionToken, collection);
     }
-    entities.forEach(entity => {
+    entities.forEach((entity) => {
       if (collection!.includes(entity)) {
         return;
       }
@@ -28,7 +29,9 @@ export class EntitiesMetadataStorage {
     });
   }
 
-  static getEntitiesByConnection(connection: ConnectionToken): Function[] {
+  static getEntitiesByConnection(
+    connection: ConnectionToken,
+  ): EntityClassOrSchema[] {
     const connectionToken =
       typeof connection === 'string' ? connection : connection.name;
 

--- a/lib/interfaces/entity-class-or-schema.type.ts
+++ b/lib/interfaces/entity-class-or-schema.type.ts
@@ -1,0 +1,3 @@
+import { EntitySchema } from 'typeorm';
+
+export type EntityClassOrSchema = Function | EntitySchema;

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -1,6 +1,7 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { Connection, ConnectionOptions } from 'typeorm';
+import { Connection, ConnectionOptions, EntitySchema } from 'typeorm';
 import { EntitiesMetadataStorage } from './entities-metadata.storage';
+import { EntityClassOrSchema } from './interfaces/entity-class-or-schema.type';
 import {
   TypeOrmModuleAsyncOptions,
   TypeOrmModuleOptions,
@@ -19,7 +20,7 @@ export class TypeOrmModule {
   }
 
   static forFeature(
-    entities: Function[] = [],
+    entities: EntityClassOrSchema[] = [],
     connection:
       | Connection
       | ConnectionOptions

--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -6,17 +6,19 @@ import {
   Repository,
 } from 'typeorm';
 import { getConnectionToken, getRepositoryToken } from './common/typeorm.utils';
+import { EntityClassOrSchema } from './interfaces/entity-class-or-schema.type';
 
 export function createTypeOrmProviders(
-  entities?: Function[],
+  entities?: EntityClassOrSchema[],
   connection?: Connection | ConnectionOptions | string,
 ): Provider[] {
-  return (entities || []).map(entity => ({
+  return (entities || []).map((entity) => ({
     provide: getRepositoryToken(entity, connection),
     useFactory: (connection: Connection) => {
       if (
-        entity.prototype instanceof Repository ||
-        entity.prototype instanceof AbstractRepository
+        entity instanceof Function &&
+        (entity.prototype instanceof Repository ||
+          entity.prototype instanceof AbstractRepository)
       ) {
         return connection.getCustomRepository(entity);
       }

--- a/tests/e2e/typeorm-schema.spec.ts
+++ b/tests/e2e/typeorm-schema.spec.ts
@@ -1,0 +1,30 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Server } from 'http';
+import * as request from 'supertest';
+import { AppSchemaModule } from '../src/app-schema.module';
+
+describe('TypeOrm', () => {
+  let server: Server;
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppSchemaModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+  });
+
+  it(`should return created entity`, () => {
+    return request(server)
+      .post('/photo')
+      .expect(201, { name: 'Nest', description: 'Is great!', views: 6000 });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/app-schema.module.ts
+++ b/tests/src/app-schema.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '../../lib';
+import { PhotoSchemaModule } from './photo/schema/photo-schema.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: '0.0.0.0',
+      port: 3306,
+      username: 'root',
+      password: 'root',
+      database: 'test',
+      synchronize: true,
+      autoLoadEntities: true,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    }),
+    PhotoSchemaModule,
+    TypeOrmModule.forRoot({
+      name: 'connection_2',
+      type: 'postgres',
+      host: '0.0.0.0',
+      port: 3306,
+      username: 'root',
+      password: 'root',
+      database: 'test',
+      synchronize: true,
+      autoLoadEntities: true,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    }),
+  ],
+})
+export class AppSchemaModule {}

--- a/tests/src/database.module.ts
+++ b/tests/src/database.module.ts
@@ -5,7 +5,7 @@ import { Photo } from './photo/photo.entity';
 @Module({})
 export class DatabaseModule {
   static async forRoot(): Promise<DynamicModule> {
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     return {
       module: DatabaseModule,
       imports: [

--- a/tests/src/photo/schema/photo-schema.controller.ts
+++ b/tests/src/photo/schema/photo-schema.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post } from '@nestjs/common';
+import { Photo } from '../photo.entity';
+import { PhotoSchemaService } from './photo-schema.service';
+
+@Controller('photo')
+export class PhotoSchemaController {
+  constructor(private readonly photoService: PhotoSchemaService) {}
+
+  @Get()
+  findAll(): Promise<Photo[]> {
+    return this.photoService.findAll();
+  }
+
+  @Post()
+  create(): Promise<Photo> {
+    return this.photoService.create();
+  }
+}

--- a/tests/src/photo/schema/photo-schema.module.ts
+++ b/tests/src/photo/schema/photo-schema.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '../../../../lib';
+import { PhotoSchemaController } from './photo-schema.controller';
+import { CustomPhotoSchemaRepository } from './photo-schema.repository';
+import { PhotoSchemaService } from './photo-schema.service';
+import { PhotoWithoutTargetSchema } from './photo-without-target.schema';
+import { PhotoSchema } from './photo.schema';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PhotoWithoutTargetSchema]),
+    TypeOrmModule.forFeature([PhotoSchema, CustomPhotoSchemaRepository]),
+    TypeOrmModule.forFeature(
+      [PhotoSchema, CustomPhotoSchemaRepository],
+      'connection_2',
+    ),
+  ],
+  providers: [PhotoSchemaService],
+  controllers: [PhotoSchemaController],
+})
+export class PhotoSchemaModule {}

--- a/tests/src/photo/schema/photo-schema.repository.ts
+++ b/tests/src/photo/schema/photo-schema.repository.ts
@@ -1,0 +1,6 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { Photo } from '../photo.entity';
+import { PhotoSchema } from './photo.schema';
+
+@EntityRepository(PhotoSchema)
+export class CustomPhotoSchemaRepository extends Repository<Photo> {}

--- a/tests/src/photo/schema/photo-schema.service.ts
+++ b/tests/src/photo/schema/photo-schema.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '../../../../lib';
+import { Photo } from '../photo.entity';
+import { CustomPhotoSchemaRepository } from './photo-schema.repository';
+import { PhotoWithoutTargetSchema } from './photo-without-target.schema';
+import { PhotoSchema } from './photo.schema';
+
+@Injectable()
+export class PhotoSchemaService {
+  constructor(
+    @InjectRepository(PhotoWithoutTargetSchema)
+    private readonly photoWithoutTargetRepository: Repository<Photo>,
+    @InjectRepository(PhotoSchema, 'connection_2')
+    private readonly photoRepository2: Repository<Photo>,
+    @InjectRepository(PhotoSchema)
+    private readonly photoRepository: Repository<Photo>,
+    @InjectRepository(CustomPhotoSchemaRepository, 'connection_2')
+    private readonly customPhotoRepository2: CustomPhotoSchemaRepository,
+    private readonly customPhotoRepository: CustomPhotoSchemaRepository,
+  ) {}
+
+  async findAll(): Promise<Photo[]> {
+    return await this.photoRepository.find();
+  }
+
+  async create(): Promise<Photo> {
+    const photoEntity = new Photo();
+    photoEntity.name = 'Nest';
+    photoEntity.description = 'Is great!';
+    photoEntity.views = 6000;
+
+    return await this.photoRepository.create(photoEntity);
+  }
+}

--- a/tests/src/photo/schema/photo-without-target.schema.ts
+++ b/tests/src/photo/schema/photo-without-target.schema.ts
@@ -1,0 +1,28 @@
+import { EntitySchema } from 'typeorm';
+import { Photo } from '../photo.entity';
+
+export const PhotoWithoutTargetSchema = new EntitySchema<Photo>({
+  name: 'photo-without-target',
+  columns: {
+    id: {
+      type: Number,
+      generated: true,
+      primary: true,
+    },
+    name: {
+      type: String,
+    },
+    description: {
+      type: String,
+    },
+    filename: {
+      type: String,
+    },
+    views: {
+      type: Number,
+    },
+    isPublished: {
+      type: Boolean,
+    },
+  },
+});

--- a/tests/src/photo/schema/photo.schema.ts
+++ b/tests/src/photo/schema/photo.schema.ts
@@ -1,0 +1,29 @@
+import { EntitySchema } from 'typeorm';
+import { Photo } from '../photo.entity';
+
+export const PhotoSchema = new EntitySchema<Photo>({
+  name: 'Photo',
+  target: Photo,
+  columns: {
+    id: {
+      type: Number,
+      generated: true,
+      primary: true,
+    },
+    name: {
+      type: String,
+    },
+    description: {
+      type: String,
+    },
+    filename: {
+      type: String,
+    },
+    views: {
+      type: Number,
+    },
+    isPublished: {
+      type: Boolean,
+    },
+  },
+});


### PR DESCRIPTION
closes nestjs/typeorm#151

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features) nestjs/docs.nestjs.com/pull/1172


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Now it is not possible to use EntitySchema with Nestjs/TypeOrm without using ts-ignore and casting as an any. 


Issue Number: #151


## What is the new behavior?
Module correctly resolves EntitySchema as a valid Entity, creates providers for that entity. We can use EntitySchema instance with the InjectRepository decorator.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information