### PR TITLE
feat(@nestjs/typeorm): add connection name to retry message

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -110,15 +110,21 @@ export function getEntityManagerToken(
 export function handleRetry(
   retryAttempts = 9,
   retryDelay = 3000,
+  connectionName = DEFAULT_CONNECTION_NAME,
 ): <T>(source: Observable<T>) => Observable<T> {
   return <T>(source: Observable<T>) =>
     source.pipe(
-      retryWhen(e =>
+      retryWhen((e) =>
         e.pipe(
           scan((errorCount, error: Error) => {
+            const namedConnection =
+              connectionName === DEFAULT_CONNECTION_NAME
+                ? ''
+                : ` (${connectionName})`;
             logger.error(
-              `Unable to connect to the database. Retrying (${errorCount +
-                1})...`,
+              `Unable to connect to the database${namedConnection}. Retrying (${
+                errorCount + 1
+              })...`,
               error.stack,
             );
             if (errorCount + 1 >= retryAttempts) {

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -177,6 +177,8 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
       }
     } catch {}
 
+    const connectionToken = options.name || DEFAULT_CONNECTION_NAME;
+
     return await defer(() => {
       if (!options.type) {
         return createConnection();
@@ -185,7 +187,6 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
         return createConnection(options as ConnectionOptions);
       }
 
-      const connectionToken = options.name || DEFAULT_CONNECTION_NAME;
       let entities = options.entities;
       if (entities) {
         entities = entities.concat(
@@ -201,7 +202,9 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
         entities,
       } as ConnectionOptions);
     })
-      .pipe(handleRetry(options.retryAttempts, options.retryDelay))
+      .pipe(
+        handleRetry(options.retryAttempts, options.retryDelay, connectionToken),
+      )
       .toPromise();
   }
 }


### PR DESCRIPTION
Enable easier debugging when using multiple named connections.

Resolves #484

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #484


## What is the new behavior?

Retry connection log message displays connection name.


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information