### PR TITLE
docs(contributing): fix commit message examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,10 +183,10 @@ Footer should contain a [closing reference to an issue](https://help.github.com/
 Samples: (even more [samples](https://github.com/nestjs/nest/commits/master))
 
 ```
-docs(changelog) update change log to beta.5
+docs(changelog): update change log to beta.5
 ```
 ```
-bugfix(@nestjs/core) need to depend on latest rxjs and zone.js
+bugfix(@nestjs/core): need to depend on latest rxjs and zone.js
 
 The version in our package.json gets copied to the one we publish, and users need the latest of these.
 ```


### PR DESCRIPTION
Message format requires colon between type and subject.

My commit failed when I omitted the colon. I do see some commits on other nest projects that do not have the colon. Not sure exactly what the rule is supposed to be.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: Documentation
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information