### PR TITLE
Using custom repository, not need to add entity to TypeOrmModule.forFeature

### DIFF
--- a/lib/typeorm.custom.repository.ts
+++ b/lib/typeorm.custom.repository.ts
@@ -1,0 +1,33 @@
+import {EntityClassOrSchema} from "./interfaces/entity-class-or-schema.type";
+import {AbstractRepository, getMetadataArgsStorage, Repository} from "typeorm";
+
+
+export function getCustomRepositoryEntity(entities: EntityClassOrSchema[]): Array<EntityClassOrSchema> {
+    let customRepositoryEntities = new Array<EntityClassOrSchema>();
+    for (let entity of entities) {
+        if (
+            entity instanceof Function &&
+            (entity.prototype instanceof Repository ||
+                entity.prototype instanceof AbstractRepository)
+        ) {
+            const entityRepositoryMetadataArgs = getMetadataArgsStorage().entityRepositories.find(
+                (repository) => {
+                    return (
+                        repository.target ===
+                        (entity instanceof Function
+                            ? entity
+                            : (entity as any).constructor)
+                    );
+                },
+            );
+            if (entityRepositoryMetadataArgs) {
+                if (
+                    entities.indexOf(<EntityClassOrSchema>entityRepositoryMetadataArgs.entity) === -1
+                ) {
+                    customRepositoryEntities.push(<EntityClassOrSchema>entityRepositoryMetadataArgs.entity);
+                }
+            }
+        }
+    }
+    return customRepositoryEntities;
+}

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -34,7 +34,7 @@ export class TypeOrmModule {
       | string = DEFAULT_CONNECTION_NAME,
   ): DynamicModule {
     const providers = createTypeOrmProviders(entities, connection);
-    let repEntities = [];
+    let customRepositoryEntities = [];
     for (let entity of entities) {
       if (
         entity instanceof Function &&
@@ -55,14 +55,14 @@ export class TypeOrmModule {
           if (
             entities.indexOf(<any>entityRepositoryMetadataArgs.entity) === -1
           ) {
-            repEntities.push(entityRepositoryMetadataArgs.entity);
+            customRepositoryEntities.push(entityRepositoryMetadataArgs.entity);
           }
         }
       }
     }
     EntitiesMetadataStorage.addEntitiesByConnection(connection, [
       ...entities,
-      ...repEntities,
+      ...customRepositoryEntities,
     ]);
     return {
       module: TypeOrmModule,

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -1,21 +1,12 @@
-import { DynamicModule, Module } from '@nestjs/common';
-import {
-  AbstractRepository,
-  Connection,
-  ConnectionOptions,
-  EntitySchema,
-  getMetadataArgsStorage,
-  Repository,
-} from 'typeorm';
-import { EntitiesMetadataStorage } from './entities-metadata.storage';
-import { EntityClassOrSchema } from './interfaces/entity-class-or-schema.type';
-import {
-  TypeOrmModuleAsyncOptions,
-  TypeOrmModuleOptions,
-} from './interfaces/typeorm-options.interface';
-import { TypeOrmCoreModule } from './typeorm-core.module';
-import { DEFAULT_CONNECTION_NAME } from './typeorm.constants';
-import { createTypeOrmProviders } from './typeorm.providers';
+import {DynamicModule, Module} from '@nestjs/common';
+import {Connection, ConnectionOptions,} from 'typeorm';
+import {EntitiesMetadataStorage} from './entities-metadata.storage';
+import {EntityClassOrSchema} from './interfaces/entity-class-or-schema.type';
+import {TypeOrmModuleAsyncOptions, TypeOrmModuleOptions,} from './interfaces/typeorm-options.interface';
+import {TypeOrmCoreModule} from './typeorm-core.module';
+import {DEFAULT_CONNECTION_NAME} from './typeorm.constants';
+import {createTypeOrmProviders} from './typeorm.providers';
+import {getCustomRepositoryEntity} from "./typeorm.custom.repository";
 
 @Module({})
 export class TypeOrmModule {
@@ -34,32 +25,7 @@ export class TypeOrmModule {
       | string = DEFAULT_CONNECTION_NAME,
   ): DynamicModule {
     const providers = createTypeOrmProviders(entities, connection);
-    let customRepositoryEntities = [];
-    for (let entity of entities) {
-      if (
-        entity instanceof Function &&
-        (entity.prototype instanceof Repository ||
-          entity.prototype instanceof AbstractRepository)
-      ) {
-        const entityRepositoryMetadataArgs = getMetadataArgsStorage().entityRepositories.find(
-          (repository) => {
-            return (
-              repository.target ===
-              (entity instanceof Function
-                ? entity
-                : (entity as any).constructor)
-            );
-          },
-        );
-        if (entityRepositoryMetadataArgs) {
-          if (
-            entities.indexOf(<any>entityRepositoryMetadataArgs.entity) === -1
-          ) {
-            customRepositoryEntities.push(entityRepositoryMetadataArgs.entity);
-          }
-        }
-      }
-    }
+    let customRepositoryEntities = getCustomRepositoryEntity(entities);
     EntitiesMetadataStorage.addEntitiesByConnection(connection, [
       ...entities,
       ...customRepositoryEntities,

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -1,11 +1,14 @@
-import {DynamicModule, Module} from '@nestjs/common';
-import {Connection, ConnectionOptions,} from 'typeorm';
-import {EntitiesMetadataStorage} from './entities-metadata.storage';
-import {EntityClassOrSchema} from './interfaces/entity-class-or-schema.type';
-import {TypeOrmModuleAsyncOptions, TypeOrmModuleOptions,} from './interfaces/typeorm-options.interface';
-import {TypeOrmCoreModule} from './typeorm-core.module';
-import {DEFAULT_CONNECTION_NAME} from './typeorm.constants';
-import {createTypeOrmProviders} from './typeorm.providers';
+import { DynamicModule, Module } from '@nestjs/common';
+import { Connection, ConnectionOptions, EntitySchema } from 'typeorm';
+import { EntitiesMetadataStorage } from './entities-metadata.storage';
+import { EntityClassOrSchema } from './interfaces/entity-class-or-schema.type';
+import {
+  TypeOrmModuleAsyncOptions,
+  TypeOrmModuleOptions,
+} from './interfaces/typeorm-options.interface';
+import { TypeOrmCoreModule } from './typeorm-core.module';
+import { DEFAULT_CONNECTION_NAME } from './typeorm.constants';
+import { createTypeOrmProviders } from './typeorm.providers';
 import {getCustomRepositoryEntity} from "./typeorm.custom.repository";
 
 @Module({})


### PR DESCRIPTION
Now if you want to use custom repository, you must have to add entity to TypeOrmModule.forFeature method, otherwise No metadata for {entity} was found error  will happen. 