### PR TITLE
fix(): stop app with unexpected error when the connection is not ready

### DIFF
--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -112,7 +112,7 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
     try {
       connection && (await connection.close());
     } catch (e) {
-      this.logger.error(e.message);
+      this.logger.error(e?.message);
     }
   }
 

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -6,6 +6,7 @@ import {
   OnApplicationShutdown,
   Provider,
   Type,
+  Logger,
 } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { defer } from 'rxjs';
@@ -33,6 +34,8 @@ import { TYPEORM_MODULE_ID, TYPEORM_MODULE_OPTIONS } from './typeorm.constants';
 @Global()
 @Module({})
 export class TypeOrmCoreModule implements OnApplicationShutdown {
+  private readonly logger = new Logger('TypeOrmModule');
+
   constructor(
     @Inject(TYPEORM_MODULE_OPTIONS)
     private readonly options: TypeOrmModuleOptions,
@@ -106,7 +109,11 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
     const connection = this.moduleRef.get<Connection>(
       getConnectionToken(this.options as ConnectionOptions) as Type<Connection>,
     );
-    connection && (await connection.close());
+    try {
+      connection && (await connection.close());
+    } catch (e) {
+      this.logger.error(e.message);
+    }
   }
 
   private static createAsyncProviders(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```
(node:31429) UnhandledPromiseRejectionWarning: CannotExecuteNotConnectedError: Cannot execute operation on "default" connection because connection is not yet established.
    at new CannotExecuteNotConnectedError (/Users/zhaofeng/workspace/yr/yanrong.tech/src/error/CannotExecuteNotConnectedError.ts:8:9)
    at Connection.<anonymous> (/Users/zhaofeng/workspace/yr/yanrong.tech/src/connection/Connection.ts:226:19)
    at step (/Users/zhaofeng/workspace/yr/yanrong.tech/node_modules/typeorm/node_modules/tslib/tslib.js:141:27)
    at Object.next (/Users/zhaofeng/workspace/yr/yanrong.tech/node_modules/typeorm/node_modules/tslib/tslib.js:122:57)
    at /Users/zhaofeng/workspace/yr/yanrong.tech/node_modules/typeorm/node_modules/tslib/tslib.js:115:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/Users/zhaofeng/workspace/yr/yanrong.tech/node_modules/typeorm/node_modules/tslib/tslib.js:111:16)
    at Connection.close (/Users/zhaofeng/workspace/yr/yanrong.tech/node_modules/typeorm/connection/Connection.js:169:24)
    at TypeOrmCoreModule.<anonymous> (/Users/zhaofeng/workspace/yr/yanrong.tech/node_modules/@nestjs/typeorm/dist/typeorm-core.module.js:95:45)
    at Generator.next (<anonymous>)

```

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information