### PR TITLE
fix(): change the injection tokens to avoid potential conflicts

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -42,9 +42,9 @@ export function getRepositoryToken(
   if (entity instanceof EntitySchema) {
     return `${connectionPrefix}${
       entity.options.target ? entity.options.target.name : entity.options.name
-    }Repository`;
+    }Repository-Token`;
   }
-  return `${connectionPrefix}${entity.name}Repository`;
+  return `${connectionPrefix}${entity.name}Repository-Token`;
 }
 
 /**
@@ -71,10 +71,10 @@ export function getConnectionToken(
   return DEFAULT_CONNECTION_NAME === connection
     ? Connection
     : 'string' === typeof connection
-    ? `${connection}Connection`
+    ? `${connection}Connection-Token`
     : DEFAULT_CONNECTION_NAME === connection.name || !connection.name
     ? Connection
-    : `${connection.name}Connection`;
+    : `${connection.name}Connection-Token`;
 }
 
 /**
@@ -110,10 +110,10 @@ export function getEntityManagerToken(
   return DEFAULT_CONNECTION_NAME === connection
     ? EntityManager
     : 'string' === typeof connection
-    ? `${connection}EntityManager`
+    ? `${connection}EntityManager-Token`
     : DEFAULT_CONNECTION_NAME === connection.name || !connection.name
     ? EntityManager
-    : `${connection.name}EntityManager`;
+    : `${connection.name}EntityManager-Token`;
 }
 
 export function handleRetry(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

User defined classes which by chance have the same name of an internal generated injection token will cause conflicts within the module injector, for example the following code does not work because the ItemRepository has been defined both by the TypeOrmModule and the user defined module ItemsModule.
Since the TypeOrmModule providers are opaque to the user who uses the injection decorators  there is no harm to change the token for the providers.

```ts
// item.entity.ts

@Entity()
class Item {
  // ...
}

// item.repository.ts

@Injectable()
class ItemRepository {
  constructor(@InjectRepository(Item) private repo: Repository<Item>) {}
}

// items.module.ts
@Module({
  imports: [TypeOrmModule.forFeature([Item])],
  providers: [
    ItemRepository,
  ]
})
class ItemsModule {}

```

## What is the new behavior?

by adding the '-Token' in the tokens we avoid potential conflicts with
other user defined services in the same module because '-' is not
valid in class names.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
