### PR TITLE
feat: allow adding providers when the module is loaded asynchronously

### DIFF
--- a/lib/interfaces/typeorm-options.interface.ts
+++ b/lib/interfaces/typeorm-options.interface.ts
@@ -1,4 +1,4 @@
-import { ModuleMetadata, Type } from '@nestjs/common';
+import {ModuleMetadata, Provider, Type} from '@nestjs/common';
 import { Connection, ConnectionOptions } from 'typeorm';
 
 export type TypeOrmModuleOptions = {
@@ -54,4 +54,5 @@ export interface TypeOrmModuleAsyncOptions
   ) => Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions;
   connectionFactory?: TypeOrmConnectionFactory;
   inject?: any[];
+  extraProviders?: Provider[];
 }

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -104,6 +104,7 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
           provide: TYPEORM_MODULE_ID,
           useValue: generateString(),
         },
+        ...(options.extraProviders || []),
       ],
       exports: [entityManagerProvider, connectionProvider],
     };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

It may be a bug fix or a feature, I'm not sure how you consider this PR

## What is the current behavior?
Today, when calling the `forRootAsync` function, it is not possible to define your own providers if necessary

Issue Number: N/A


## What is the new behavior?

Here is an example in one of my projects where I want to encapsulate the declaration of the `TypeOrmModule` module in my own `DatabaseModule` module so as not to repeat the declaration of my logger or other common options several times. This module is at the root of my Git repository and is used in different NestJS applications that I have in this same Git repository

- `database.module.ts`
```ts
export type DatabaseModuleOptions = TypeOrmModuleOptions
export type DatabaseModuleAsyncOptions = Pick<ModuleMetadata, 'imports'> & {
  useFactory: (
    ...args: any[]
  ) => DatabaseModuleOptions | Promise<DatabaseModuleOptions>;
  inject?: any[];
};

@Module({})
export class DatabaseModule {
  static forRootAsync(options: DatabaseModuleAsyncOptions): DynamicModule {
    return {
      module: DatabaseModule,
      imports: [
        TypeOrmModule.forRootAsync({
          imports: options.imports,
          providers: [
            {
              provide: 'DATABASE_MODULE_OPTIONS',
              useFactory: options.useFactory,
              inject: options.inject,
            },
          ],
          inject: ['DATABASE_MODULE_OPTIONS', PinoLogger],
          useFactory: (options: DatabaseModuleOptions, logger: PinoLogger) => ({
            ...options,
            loggerLevel: 'debug',
            logger: new TypeOrmLogger(logger),
            entities: [ // ...],
          }),
        } as TypeOrmModuleAsyncOptions),
      ],
      exports: [TypeOrmModule],
    };
  }
```
- `foo.app.module.ts`
```ts
@Module({
  imports: [
    DatabaseModule.forRootAsync({
      imports: [ConfigModule],
      useFactory: (configService: ConfigService) => ({
        ...configService.get('app.database.foo'),
      }),
      inject: [ConfigService],
    }),
  ]
})
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
What do you think of this modification to allow to simply add providers?