### PR TITLE
Check if datasource is initialized before destroying it

### DIFF
--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -137,7 +137,9 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
       getDataSourceToken(this.options as DataSourceOptions) as Type<DataSource>,
     );
     try {
-      dataSource && (await dataSource.destroy());
+      if (dataSource && dataSource.isInitialized) {
+        await dataSource.destroy();
+      }
     } catch (e) {
       this.logger.error(e?.message);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
If a NestJS app destroys a `dataSource` instance before app shutdown, they will see the following error:

```
Cannot execute operation on "default" connection because connection is not yet established.
```

Issue Number: N/A


## What is the new behavior?
A NestJS app can destroy a `dataSource` instance before app shutdown and they will not see the following error logged:

```
Cannot execute operation on "default" connection because connection is not yet established.
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
