### PR TITLE
Do not initialize datasource if already initialized

### DIFF
--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -217,7 +217,7 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
           const dataSource = await createTypeormDataSource(
             options as DataSourceOptions,
           );
-          return dataSource.initialize ? dataSource.initialize() : dataSource;
+          return dataSource.initialize && !dataSource.isInitialized ? dataSource.initialize() : dataSource;
         }
 
         let entities = options.entities;
@@ -233,7 +233,7 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
           ...options,
           entities,
         } as DataSourceOptions);
-        return dataSource.initialize ? dataSource.initialize() : dataSource;
+        return dataSource.initialize && !dataSource.isInitialized ? dataSource.initialize() : dataSource;
       }).pipe(
         handleRetry(
           options.retryAttempts,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Initialising datasource in dataSourceFactory throw an exceprtion 
But docs says that it is correct usage 
```ts
TypeOrmModule.forRootAsync({
  imports: [ConfigModule],
  inject: [ConfigService],
  // Use useFactory, useClass, or useExisting
  // to configure the DataSourceOptions.
  useFactory: (configService: ConfigService) => ({
    type: 'mysql',
    host: configService.get('HOST'),
    port: +configService.get('PORT'),
    username: configService.get('USERNAME'),
    password: configService.get('PASSWORD'),
    database: configService.get('DATABASE'),
    entities: [],
    synchronize: true,
  }),
  // dataSource receives the configured DataSourceOptions
  // and returns a Promise<DataSource>.
  dataSourceFactory: async (options) => {
    const dataSource = await new DataSource(options).initialize();
    return dataSource;
  },
});
```

You should destroy datasource before return
```ts
TypeOrmModule.forRootAsync({
  imports: [ConfigModule],
  inject: [ConfigService],
  // Use useFactory, useClass, or useExisting
  // to configure the DataSourceOptions.
  useFactory: (configService: ConfigService) => ({
    type: 'mysql',
    host: configService.get('HOST'),
    port: +configService.get('PORT'),
    username: configService.get('USERNAME'),
    password: configService.get('PASSWORD'),
    database: configService.get('DATABASE'),
    entities: [],
    synchronize: true,
  }),
  // dataSource receives the configured DataSourceOptions
  // and returns a Promise<DataSource>.
  dataSourceFactory: async (options) => {
    const dataSource = await new DataSource(options).initialize();
    
    //do some stuff here, then
    
    await dataSource.destroy()
    
    return dataSource;
  },
});
```


## What is the new behavior?

Users can safely initialize datasource in dataSourceFactory and should not destroy it

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information



