### PR TITLE
fix(provider): return proper repository

### DIFF
--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -10,10 +10,10 @@ export function createTypeOrmProviders(
   return (entities || []).map((entity) => ({
     provide: getRepositoryToken(entity, dataSource),
     useFactory: (dataSource: DataSource) => {
-      const enitityMetadata = dataSource.entityMetadatas.find( meta => meta.target === entity )
+      const enitityMetadata = dataSource.entityMetadatas.find((meta) => meta.target === entity)
       const isTreeEntity = typeof enitityMetadata?.treeType !== 'undefined'
       return isTreeEntity 
-        ? dataSource.getTreeRepository( entity )
+        ? dataSource.getTreeRepository(entity)
         : dataSource.options.type === 'mongodb'
           ? dataSource.getMongoRepository(entity)
           : dataSource.getRepository(entity);

--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -10,9 +10,13 @@ export function createTypeOrmProviders(
   return (entities || []).map((entity) => ({
     provide: getRepositoryToken(entity, dataSource),
     useFactory: (dataSource: DataSource) => {
-      return dataSource.options.type === 'mongodb'
-        ? dataSource.getMongoRepository(entity)
-        : dataSource.getRepository(entity);
+      const enitityMetadata = dataSource.entityMetadatas.find( meta => meta.target === entity )
+      const isTreeEntity = typeof enitityMetadata?.treeType !== 'undefined'
+      return isTreeEntity 
+        ? dataSource.getTreeRepository( entity )
+        : dataSource.options.type === 'mongodb'
+          ? dataSource.getMongoRepository(entity)
+          : dataSource.getRepository(entity);
     },
     inject: [getDataSourceToken(dataSource)],
     /**


### PR DESCRIPTION
check if the entity has tree metadata and return a tree repository if it exists

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the providers don't return a TreeRepository for tree entities.

## What is the new behavior?
Now the provider will create and return a tree repository for tree entities

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
