### PR TITLE
chore(type): make name option for forRootAsync() required

### DIFF
--- a/lib/interfaces/typeorm-options.interface.ts
+++ b/lib/interfaces/typeorm-options.interface.ts
@@ -47,7 +47,7 @@ export type TypeOrmDataSourceFactory = (
 
 export interface TypeOrmModuleAsyncOptions
   extends Pick<ModuleMetadata, 'imports'> {
-  name?: string;
+  name: string;
   useExisting?: Type<TypeOrmOptionsFactory>;
   useClass?: Type<TypeOrmOptionsFactory>;
   useFactory?: (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`name` property of `TypeOrmModuleAsyncOptions` is currently optional even though it needs to be specified as mentioned in #86. 

## What is the new behavior?

`name` property of `TypeOrmModuleAsyncOptions` needs to be specified accordingly as [the documentation describes](https://docs.nestjs.com/techniques/database).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
