### PR TITLE
perf: export providers using their tokens instead

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no commitlint --edit $1
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx --no lint-staged
+npx lint-staged

--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -31,7 +31,7 @@ export class TypeOrmModule {
     return {
       module: TypeOrmModule,
       providers: providers,
-      exports: providers,
+      exports: providers.map((provider) => provider.provide),
     };
   }
 

--- a/lib/typeorm.providers.ts
+++ b/lib/typeorm.providers.ts
@@ -1,22 +1,30 @@
-import { Provider } from '@nestjs/common';
-import { DataSource, DataSourceOptions, getMetadataArgsStorage } from 'typeorm';
+import { FactoryProvider } from '@nestjs/common';
+import {
+  DataSource,
+  DataSourceOptions,
+  getMetadataArgsStorage,
+  Repository,
+  TreeRepository,
+} from 'typeorm';
 import { getDataSourceToken, getRepositoryToken } from './common/typeorm.utils';
 import { EntityClassOrSchema } from './interfaces/entity-class-or-schema.type';
 
 export function createTypeOrmProviders(
   entities?: EntityClassOrSchema[],
   dataSource?: DataSource | DataSourceOptions | string,
-): Provider[] {
+): FactoryProvider<TreeRepository<any> | Repository<any>>[] {
   return (entities || []).map((entity) => ({
     provide: getRepositoryToken(entity, dataSource),
     useFactory: (dataSource: DataSource) => {
-      const enitityMetadata = dataSource.entityMetadatas.find((meta) => meta.target === entity)
-      const isTreeEntity = typeof enitityMetadata?.treeType !== 'undefined'
-      return isTreeEntity 
+      const enitityMetadata = dataSource.entityMetadatas.find(
+        (meta) => meta.target === entity,
+      );
+      const isTreeEntity = typeof enitityMetadata?.treeType !== 'undefined';
+      return isTreeEntity
         ? dataSource.getTreeRepository(entity)
         : dataSource.options.type === 'mongodb'
-          ? dataSource.getMongoRepository(entity)
-          : dataSource.getRepository(entity);
+        ? dataSource.getMongoRepository(entity)
+        : dataSource.getRepository(entity);
     },
     inject: [getDataSourceToken(dataSource)],
     /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

I have a real-world nestjs app with 63 [eager] modules and 80 entities.  
Using `perfomance.now()` before and after `NestFactory.create()`, it always shows a diff time of ~6s

## What is the new behavior?

due to how nestjs token factory and `TypeOrmModule.forFeature` works, using only providers's token (which are just strings or functions) instead of the whole provider object at `exports`, the creation step would be faster. In the above described scenario, it tooks ~1s now :rocket: 

In another project (with less modules & entities), changing that did not improved that much tho.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

