### PR TITLE
feat(): add support for manual init

### DIFF
--- a/lib/interfaces/typeorm-options.interface.ts
+++ b/lib/interfaces/typeorm-options.interface.ts
@@ -33,6 +33,13 @@ export type TypeOrmModuleOptions = {
    * If `true`, will show verbose error messages on each connection retry.
    */
   verboseRetryLog?: boolean;
+  /**
+   * If `true` database initialization will not be performed during module initialization.
+   * This means that database connection will not be established and migrations will not run.
+   * Database initialization will have to be performed manually using `DataSource.initialize`
+   * and it will have to implement own retry mechanism (if necessary).
+   */
+  manualInitialization?: boolean;
 } & Partial<DataSourceOptions>;
 
 export interface TypeOrmOptionsFactory {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Motivation for no tests:
I searched repository for proper place to add tests for this feature but none seem to be correct (there are only e2e tests with specific convention).
I run e2e suite though and it passes.
I also tested the feature manually on my usecase (on and off).
Please suggest test convention if you want me to write tests for this feature and I will do my best to apply it.


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
There is no option to disable `DataSource` initialization during module initialization

Issue Number: 1762


## What is the new behavior?
Option `manualInitialization` was added to `TypeOrmModuleOptions` interface.
Module does not initialize database if option is set to `true`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
I have done one minor refactor to limit logic repetition
