### PR TITLE
refactor: replace `uuid` 3rd-party lib with native module

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -10,7 +10,7 @@ import {
   EntitySchema,
   Repository,
 } from 'typeorm';
-import { v4 as uuid } from 'uuid';
+import { randomUUID as uuid } from 'crypto';
 import { CircularDependencyException } from '../exceptions/circular-dependency.exception';
 import { EntityClassOrSchema } from '../interfaces/entity-class-or-schema.type';
 import { DEFAULT_DATA_SOURCE_NAME } from '../typeorm.constants';

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@nestjs/typeorm",
       "version": "10.0.0",
       "license": "MIT",
-      "dependencies": {
-        "uuid": "9.0.0"
-      },
       "devDependencies": {
         "@commitlint/cli": "17.7.1",
         "@commitlint/config-angular": "17.7.0",
@@ -21,7 +18,6 @@
         "@types/jest": "29.5.4",
         "@types/node": "18.17.12",
         "@types/supertest": "2.0.12",
-        "@types/uuid": "9.0.3",
         "@typescript-eslint/eslint-plugin": "6.5.0",
         "@typescript-eslint/parser": "6.5.0",
         "eslint": "8.48.0",
@@ -2892,12 +2888,6 @@
       "dependencies": {
         "@types/superagent": "*"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.3.tgz",
-      "integrity": "sha512-taHQQH/3ZyI3zP8M/puluDEIEvtQHVYcC6y3N8ijFtAd28+Ey/G4sg1u2gB01S8MwybLOKAp9/yCMu/uR5l3Ug==",
-      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
@@ -13969,6 +13959,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -16529,12 +16520,6 @@
       "requires": {
         "@types/superagent": "*"
       }
-    },
-    "@types/uuid": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.3.tgz",
-      "integrity": "sha512-taHQQH/3ZyI3zP8M/puluDEIEvtQHVYcC6y3N8ijFtAd28+Ey/G4sg1u2gB01S8MwybLOKAp9/yCMu/uR5l3Ug==",
-      "dev": true
     },
     "@types/yargs": {
       "version": "17.0.10",
@@ -24438,7 +24423,8 @@
     "uuid": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/jest": "29.5.4",
     "@types/node": "18.17.12",
     "@types/supertest": "2.0.12",
-    "@types/uuid": "9.0.3",
     "@typescript-eslint/eslint-plugin": "6.5.0",
     "@typescript-eslint/parser": "6.5.0",
     "eslint": "8.48.0",
@@ -48,9 +47,6 @@
     "ts-jest": "29.1.1",
     "typeorm": "0.3.17",
     "typescript": "5.2.2"
-  },
-  "dependencies": {
-    "uuid": "9.0.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- nestjs v10 is supposed to be used in nodejs v16+
- [`crypto.randomUUID`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions) was add in nodejs v14.17.0
- but this packages depends on `uuid` 3rd-party package

## What is the new behavior?

this package has no external dependencies anymore :tada: because nodejs has a native way to generate v4 uuids

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

my only concern is that this will be a breaking change for those that are forcing the usage of `@nestjs/typeorm` in nodejs versions smaller than v14.17 as there's no engine restriction here nor in `@nestjs/core` package