### PR TITLE
fix(typeorm): Warning log when multiple DataSources have the same name

### DIFF
--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -38,30 +38,24 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
   private static readonly logger = new Logger('TypeOrmModule');
 
   private static validateDataSourceNames(
-    options: TypeOrmModuleOptions | TypeOrmModuleOptions[],
+    options: TypeOrmModuleOptions | TypeOrmModuleOptions[]
   ): void {
     const configs = Array.isArray(options) ? options : [options];
-    const names = new Map<string, number>();
+    const names = new Set<string>();
 
-    configs.forEach((config) => {
-      if (!config) {
-        return;
+    for (const config of configs) {
+      if (!config.name) {
+        continue;
       }
-      const name = (config as any).name || 'default';
-      const count = names.get(name) || 0;
-      names.set(name, count + 1);
-    });
-
-    const duplicates = Array.from(names.entries())
-      .filter(([_, occurrences]) => occurrences > 1)
-      .map(([name]) => name);
-
-    if (duplicates.length > 0) {
-      this.logger.warn(
-        `⚠️ WARNING: Duplicate DataSource names detected: [${duplicates.join(', ')}]. ` +
-          `Each DataSource should have a unique name to avoid conflicts.` +
-          `Multiple DataSources with default name will result in unexpected behaviour.`,
-      );
+      if (!names.has(config.name)) {
+        names.add(config.name);
+      } else {
+        this.logger.warn(
+          `⚠️ WARNING: Duplicate DataSource names detected: [${config.name}]. ` +
+            `Each DataSource should have a unique name to avoid conflicts.` +
+            `Multiple DataSources with default name will result in unexpected behaviour.`
+        );
+      }
     }
   }
 

--- a/tests/e2e/typeorm-duplicate-datasource-names.spec.ts
+++ b/tests/e2e/typeorm-duplicate-datasource-names.spec.ts
@@ -1,0 +1,143 @@
+import { TypeOrmCoreModule } from '../../lib/typeorm-core.module';
+import { Logger } from '@nestjs/common';
+
+describe('TypeOrmModule - validateDataSourceNames', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest
+      .spyOn((TypeOrmCoreModule as any).logger, 'warn')
+      .mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should log a warning when duplicate data source names are provided', () => {
+    const options = [
+      { name: 'default', type: 'sqlite', database: ':memory:' },
+      { name: 'secondary', type: 'sqlite', database: ':memory:' },
+      { name: 'secondary', type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Duplicate DataSource names detected: [secondary]',
+      ),
+    );
+  });
+
+  it('should not log a warning when all data source names are unique', () => {
+    const options = [
+      { name: 'default', type: 'sqlite', database: ':memory:' },
+      { name: 'secondary', type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should treat missing names as "default" and log warning if repeated', () => {
+    const options = [
+      { type: 'sqlite', database: ':memory:' },
+      { type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Duplicate DataSource names detected: [default]'),
+    );
+  });
+
+  it('should not log warning for a single configuration object', () => {
+    const options = { name: 'default', type: 'sqlite', database: ':memory:' };
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle an empty array without throwing or logging', () => {
+    const options: any[] = [];
+
+    expect(() => {
+      (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+    }).not.toThrow();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle mixed named and unnamed configurations correctly', () => {
+    const options = [
+      { name: 'primary', type: 'sqlite', database: ':memory:' },
+      { type: 'sqlite', database: ':memory:' },
+      { type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Duplicate DataSource names detected: [default]'),
+    );
+  });
+
+  it('should log warning when multiple different duplicates exist', () => {
+    const options = [
+      { name: 'alpha', type: 'sqlite', database: ':memory:' },
+      { name: 'alpha', type: 'sqlite', database: ':memory:' },
+      { name: 'beta', type: 'sqlite', database: ':memory:' },
+      { name: 'beta', type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Duplicate DataSource names detected: [alpha, beta]',
+      ),
+    );
+  });
+
+  it('should handle case-sensitive names as different (no warning)', () => {
+    const options = [
+      { name: 'Main', type: 'sqlite', database: ':memory:' },
+      { name: 'main', type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not crash if one of the configs is null or undefined', () => {
+    const options = [
+      { name: 'alpha', type: 'sqlite', database: ':memory:' },
+      null as any,
+      undefined as any,
+      { name: 'beta', type: 'sqlite', database: ':memory:' },
+    ];
+
+    expect(() => {
+      (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+    }).not.toThrow();
+  });
+
+  it('should log warning if all names are missing (multiple "default")', () => {
+    const options = [
+      { type: 'sqlite', database: ':memory:' },
+      { type: 'sqlite', database: ':memory:' },
+      { type: 'sqlite', database: ':memory:' },
+    ];
+
+    (TypeOrmCoreModule as any)['validateDataSourceNames'](options);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Duplicate DataSource names detected: [default]'),
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Multiple Data Sources could have had the same name, and no logs to warn about this issue. 

Issue Number: #2017 


## What is the new behavior?
The TypeOrmCore now checks the current name pool using a static Map, and if duplicates were found a comprehensive warning would be logged.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
