### PR TITLE
feat(typeorm): accept data source name as second forRoot argument

### DIFF
--- a/lib/typeorm.module.ts
+++ b/lib/typeorm.module.ts
@@ -15,10 +15,20 @@ import { createTypeOrmProviders } from './typeorm.providers';
  */
 @Module({})
 export class TypeOrmModule {
-  static forRoot(options?: TypeOrmModuleOptions): DynamicModule {
+  /**
+   * Registers the TypeORM module with the given options.
+   *
+   * @param options The TypeORM data source options.
+   * @param name Optional data source name. When provided, it overrides
+   * `options.name` (if any) so the data source name can be configured
+   * separately from the connection options – mirroring `forRootAsync`.
+   */
+  static forRoot(options?: TypeOrmModuleOptions, name?: string): DynamicModule {
+    const resolvedOptions =
+      name !== undefined ? { ...(options ?? {}), name } : options;
     return {
       module: TypeOrmModule,
-      imports: [TypeOrmCoreModule.forRoot(options)],
+      imports: [TypeOrmCoreModule.forRoot(resolvedOptions)],
     };
   }
 

--- a/tests/e2e/typeorm-module.spec.ts
+++ b/tests/e2e/typeorm-module.spec.ts
@@ -1,0 +1,73 @@
+import { Provider } from '@nestjs/common';
+import { TypeOrmModule } from '../../lib';
+import { TYPEORM_MODULE_OPTIONS } from '../../lib/typeorm.constants';
+
+type ValueProvider = Provider & { provide: unknown; useValue: unknown };
+
+function findOptionsValue(
+  providers: Provider[] | undefined,
+): Record<string, unknown> | undefined {
+  if (!providers) {
+    return undefined;
+  }
+  const match = providers.find(
+    (provider): provider is ValueProvider =>
+      typeof provider === 'object' &&
+      provider !== null &&
+      'provide' in provider &&
+      (provider as ValueProvider).provide === TYPEORM_MODULE_OPTIONS,
+  );
+  return match?.useValue as Record<string, unknown> | undefined;
+}
+
+describe('TypeOrmModule.forRoot', () => {
+  it('should accept a data source name as a second argument', () => {
+    const options = {
+      type: 'postgres' as const,
+      host: '0.0.0.0',
+      port: 3306,
+      username: 'root',
+      password: 'root',
+      database: 'test',
+    };
+
+    const dynamicModule = TypeOrmModule.forRoot(options, 'named');
+    const coreModule = dynamicModule.imports?.[0] as {
+      providers?: Provider[];
+    };
+    const resolvedOptions = findOptionsValue(coreModule.providers);
+
+    expect(resolvedOptions).toBeDefined();
+    expect(resolvedOptions!.name).toBe('named');
+    expect(resolvedOptions!.type).toBe('postgres');
+  });
+
+  it('should let the second argument override options.name', () => {
+    const dynamicModule = TypeOrmModule.forRoot(
+      {
+        name: 'fromOptions',
+        type: 'postgres' as const,
+      },
+      'fromArgument',
+    );
+    const coreModule = dynamicModule.imports?.[0] as {
+      providers?: Provider[];
+    };
+    const resolvedOptions = findOptionsValue(coreModule.providers);
+
+    expect(resolvedOptions!.name).toBe('fromArgument');
+  });
+
+  it('should keep options.name when no second argument is provided', () => {
+    const dynamicModule = TypeOrmModule.forRoot({
+      name: 'fromOptions',
+      type: 'postgres' as const,
+    });
+    const coreModule = dynamicModule.imports?.[0] as {
+      providers?: Provider[];
+    };
+    const resolvedOptions = findOptionsValue(coreModule.providers);
+
+    expect(resolvedOptions!.name).toBe('fromOptions');
+  });
+});


### PR DESCRIPTION
## PR Type
Feature

## Current behavior
`TypeOrmModule.forRoot()` takes a single options object. The data source name can only be set via `options.name`, which means callers cannot configure a name separately from the connection options body. This is inconsistent with `TypeOrmModule.forRootAsync()`, which already exposes a top-level `name` option that is applied outside of the options factory.

## New behavior
`forRoot` now accepts an optional second argument `name?: string`. When provided, it is merged into the options as the `name` field (overriding `options.name` if both are supplied). The existing single-argument signature is unchanged, so this is fully backward-compatible.

```ts
TypeOrmModule.forRoot({ type: 'postgres', /* ... */ }, 'analytics');
```

## Does this PR introduce a breaking change?
No.

## Other information
- Mirrors the top-level `name` option already available on `forRootAsync`, making the API consistent between the two registration styles.
- Adds unit tests in `tests/e2e/typeorm-module.spec.ts` covering: new name argument is applied, it overrides `options.name`, and existing single-argument behavior is preserved.
- Closes #66