### PR TITLE
feat: reject duplicate data source names at registration

### DIFF
--- a/lib/data-source-name.registry.ts
+++ b/lib/data-source-name.registry.ts
@@ -1,0 +1,31 @@
+import { DuplicateDataSourceException } from './exceptions/duplicate-data-source.exception';
+
+/**
+ * Tracks active data source names at runtime in order to prevent multiple
+ * data sources from being registered under the same name. Registering two
+ * data sources with the same name is unsupported by TypeORM — the second
+ * registration silently overrides the first — which is a common source
+ * of hard-to-debug configuration issues.
+ */
+export class DataSourceNameRegistry {
+  private static readonly registeredNames = new Set<string>();
+
+  static register(dataSourceName: string): void {
+    if (this.registeredNames.has(dataSourceName)) {
+      throw new DuplicateDataSourceException(dataSourceName);
+    }
+    this.registeredNames.add(dataSourceName);
+  }
+
+  static unregister(dataSourceName: string): void {
+    this.registeredNames.delete(dataSourceName);
+  }
+
+  static has(dataSourceName: string): boolean {
+    return this.registeredNames.has(dataSourceName);
+  }
+
+  static clear(): void {
+    this.registeredNames.clear();
+  }
+}

--- a/lib/exceptions/duplicate-data-source.exception.ts
+++ b/lib/exceptions/duplicate-data-source.exception.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_DATA_SOURCE_NAME } from '../typeorm.constants';
+
+export class DuplicateDataSourceException extends Error {
+  constructor(dataSourceName: string) {
+    const isDefault = dataSourceName === DEFAULT_DATA_SOURCE_NAME;
+    const descriptor = isDefault ? 'default (unnamed)' : `"${dataSourceName}"`;
+    super(
+      `A data source with the ${descriptor} name is already registered. ` +
+        `Multiple data sources must be registered with unique names; otherwise, ` +
+        `they will override each other. Please assign a unique "name" property ` +
+        `to each TypeOrmModule.forRoot()/forRootAsync() registration.`,
+    );
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './common';
+export * from './exceptions/duplicate-data-source.exception';
 export * from './interfaces';
 export * from './typeorm.module';

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -18,6 +18,7 @@ import {
   getEntityManagerToken,
   handleRetry,
 } from './common/typeorm.utils';
+import { DataSourceNameRegistry } from './data-source-name.registry';
 import { EntitiesMetadataStorage } from './entities-metadata.storage';
 import {
   TypeOrmDataSourceFactory,
@@ -39,6 +40,9 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
   ) {}
 
   static forRoot(options: TypeOrmModuleOptions = {}): DynamicModule {
+    DataSourceNameRegistry.register(
+      getDataSourceName(options as DataSourceOptions),
+    );
     const typeOrmModuleOptions = {
       provide: TYPEORM_MODULE_OPTIONS,
       useValue: options,
@@ -74,6 +78,9 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
   }
 
   static forRootAsync(options: TypeOrmModuleAsyncOptions): DynamicModule {
+    if (options.name) {
+      DataSourceNameRegistry.register(options.name);
+    }
     const dataSourceProvider = {
       provide: getDataSourceToken(options as DataSourceOptions),
       useFactory: async (typeOrmOptions: TypeOrmModuleOptions) => {
@@ -141,6 +148,10 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
       }
     } catch (e: any) {
       this.logger.error(e?.message);
+    } finally {
+      DataSourceNameRegistry.unregister(
+        getDataSourceName(this.options as DataSourceOptions),
+      );
     }
   }
 

--- a/tests/e2e/typeorm-duplicate-data-source.spec.ts
+++ b/tests/e2e/typeorm-duplicate-data-source.spec.ts
@@ -1,0 +1,106 @@
+import { Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DuplicateDataSourceException, TypeOrmModule } from '../../lib';
+
+describe('TypeOrm data source duplicate name validation', () => {
+  it('should throw when two data sources fall back to the default name', () => {
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      manualInitialization: true,
+      retryAttempts: 0,
+    });
+
+    expect(() =>
+      TypeOrmModule.forRoot({
+        type: 'postgres',
+        manualInitialization: true,
+        retryAttempts: 0,
+      }),
+    ).toThrow(DuplicateDataSourceException);
+  });
+
+  it('should throw when two data sources share a non-default name', () => {
+    TypeOrmModule.forRoot({
+      name: 'duplicate',
+      type: 'postgres',
+      manualInitialization: true,
+      retryAttempts: 0,
+    });
+
+    expect(() =>
+      TypeOrmModule.forRoot({
+        name: 'duplicate',
+        type: 'postgres',
+        manualInitialization: true,
+        retryAttempts: 0,
+      }),
+    ).toThrow(DuplicateDataSourceException);
+  });
+
+  it('should throw when forRootAsync re-registers an existing name synchronously', () => {
+    TypeOrmModule.forRoot({
+      name: 'async-dup',
+      type: 'postgres',
+      manualInitialization: true,
+      retryAttempts: 0,
+    });
+
+    expect(() =>
+      TypeOrmModule.forRootAsync({
+        name: 'async-dup',
+        useFactory: () => ({
+          type: 'postgres',
+          manualInitialization: true,
+          retryAttempts: 0,
+        }),
+      }),
+    ).toThrow(DuplicateDataSourceException);
+  });
+
+  it('should allow registering data sources with unique names', () => {
+    expect(() => {
+      TypeOrmModule.forRoot({
+        name: 'unique-a',
+        type: 'postgres',
+        manualInitialization: true,
+        retryAttempts: 0,
+      });
+      TypeOrmModule.forRoot({
+        name: 'unique-b',
+        type: 'postgres',
+        manualInitialization: true,
+        retryAttempts: 0,
+      });
+    }).not.toThrow();
+  });
+
+  it('should free the name once the module is shut down', async () => {
+    @Module({
+      imports: [
+        TypeOrmModule.forRoot({
+          name: 'reusable',
+          type: 'postgres',
+          manualInitialization: true,
+          retryAttempts: 0,
+        }),
+      ],
+    })
+    class FirstAppModule {}
+
+    const firstModuleRef = await Test.createTestingModule({
+      imports: [FirstAppModule],
+    }).compile();
+    const firstApp = firstModuleRef.createNestApplication();
+    await firstApp.init();
+    await firstApp.close();
+
+    expect(() =>
+      TypeOrmModule.forRoot({
+        name: 'reusable',
+        type: 'postgres',
+        manualInitialization: true,
+        retryAttempts: 0,
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What is the current behavior?

`TypeOrmModule.forRoot` and `TypeOrmModule.forRootAsync` silently accept multiple data source registrations with the same name. Because TypeORM internally keys data sources by name, the second registration overrides the first without any warning. The default (unnamed) case is especially easy to trip on: omitting `name` on a second `forRoot` call collapses both data sources onto the `default` name.

Fixes #2017

## What is the new behavior?

- Introduces a small `DataSourceNameRegistry` that tracks active data source names.
- `TypeOrmModule.forRoot` registers the resolved name synchronously at module construction time; `TypeOrmModule.forRootAsync` does the same when a top-level `name` is provided.
- Attempting to register an already-registered name now throws a descriptive `DuplicateDataSourceException` immediately, instead of letting the duplicate silently clobber the first data source at runtime.
- `onApplicationShutdown` releases the name, so creating/tearing down multiple test modules (or sequential app starts in the same process) keeps working.
- `DuplicateDataSourceException` is exported from the public entry point so consumers can match on it if they need to.

## Additional context

- All existing e2e specs continue to use distinct data source names (`default` + `connection_2`), so no existing scenarios are broken.
- A new spec (`tests/e2e/typeorm-duplicate-data-source.spec.ts`) exercises the duplicate-default, duplicate-named, async-vs-sync duplicate, happy-path uniqueness, and shutdown-releases-name cases against an in-memory module (no live database required).