### PR TITLE
fix(typeorm-core.module): resolve removed typeorm apis at runtime

### DIFF
--- a/lib/common/typeorm-compat.ts
+++ b/lib/common/typeorm-compat.ts
@@ -1,0 +1,48 @@
+/**
+ * Runtime compatibility helpers for accessing TypeORM APIs that were
+ * removed in TypeORM v1.0.0 (notably `Connection` and `AbstractRepository`).
+ *
+ * Importing these symbols statically from `typeorm` would produce
+ * TypeScript errors for consumers on TypeORM v1 when `skipLibCheck` is
+ * disabled, and would cause runtime crashes inside `@nestjs/typeorm`
+ * because the values resolve to `undefined`.
+ *
+ * Resolving them lazily via `require()` keeps the package working on
+ * both TypeORM 0.3.x (where the symbols still exist) and 1.0.x
+ * (where they have been removed) without forcing a type dependency.
+ */
+
+/**
+ * Safely resolves an optional export from the installed `typeorm`
+ * package. Returns `undefined` when the export is not present (e.g.
+ * TypeORM v1.0.0 has removed it) or when the module fails to load.
+ */
+function resolveTypeormExport<T = unknown>(exportName: string): T | undefined {
+  try {
+    // Using `require` here (rather than a static import) ensures the
+    // reference is resolved at runtime and is not included in the
+    // emitted type definitions — which is required for forward
+    // compatibility with TypeORM v1 where these symbols no longer exist.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const typeorm = require('typeorm') as Record<string, unknown>;
+    return typeorm[exportName] as T | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type OptionalCtor = (new (...args: any[]) => any) | undefined;
+
+/**
+ * The TypeORM `Connection` class (removed in TypeORM v1.0.0, replaced by
+ * `DataSource` since 0.3.0). Resolves to `undefined` on TypeORM v1+.
+ */
+export const Connection: OptionalCtor =
+  resolveTypeormExport<new (...args: any[]) => any>('Connection');
+
+/**
+ * The TypeORM `AbstractRepository` class (removed in TypeORM v1.0.0).
+ * Resolves to `undefined` on TypeORM v1+.
+ */
+export const AbstractRepository: OptionalCtor =
+  resolveTypeormExport<new (...args: any[]) => any>('AbstractRepository');

--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -2,7 +2,6 @@ import { Logger, Type } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { delay, retryWhen, scan } from 'rxjs/operators';
 import {
-  AbstractRepository,
   DataSource,
   DataSourceOptions,
   EntityManager,
@@ -12,6 +11,7 @@ import {
 import { CircularDependencyException } from '../exceptions/circular-dependency.exception';
 import { EntityClassOrSchema } from '../interfaces/entity-class-or-schema.type';
 import { DEFAULT_DATA_SOURCE_NAME } from '../typeorm.constants';
+import { AbstractRepository } from './typeorm-compat';
 
 const logger = new Logger('TypeOrmModule');
 
@@ -85,8 +85,7 @@ export function getDataSourceToken(
     ? DataSource
     : 'string' === typeof dataSource
       ? `${dataSource}DataSource`
-      : DEFAULT_DATA_SOURCE_NAME === dataSource.name ||
-          !dataSource.name
+      : DEFAULT_DATA_SOURCE_NAME === dataSource.name || !dataSource.name
         ? DataSource
         : `${dataSource.name}DataSource`;
 }
@@ -116,10 +115,7 @@ export function getDataSourcePrefix(
   if (typeof dataSource === 'string') {
     return dataSource + '_';
   }
-  if (
-    dataSource.name === DEFAULT_DATA_SOURCE_NAME ||
-    !dataSource.name
-  ) {
+  if (dataSource.name === DEFAULT_DATA_SOURCE_NAME || !dataSource.name) {
     return '';
   }
   return dataSource.name + '_';
@@ -141,8 +137,7 @@ export function getEntityManagerToken(
     ? EntityManager
     : 'string' === typeof dataSource
       ? `${dataSource}EntityManager`
-      : DEFAULT_DATA_SOURCE_NAME === dataSource.name ||
-          !dataSource.name
+      : DEFAULT_DATA_SOURCE_NAME === dataSource.name || !dataSource.name
         ? EntityManager
         : `${dataSource.name}EntityManager`;
 }

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -10,7 +10,8 @@ import {
 } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { defer, lastValueFrom } from 'rxjs';
-import { Connection, DataSource, DataSourceOptions } from 'typeorm';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { Connection } from './common/typeorm-compat';
 import {
   generateString,
   getDataSourceName,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## What is the current behavior?

Follow-up to #2562. That PR added runtime guards (`if (Connection && ...)`) so the backwards-compat code paths would be skipped on TypeORM v1.0.0, but it kept the static imports of `Connection` (in `lib/typeorm-core.module.ts`) and `AbstractRepository` (in `lib/common/typeorm.utils.ts`) from `typeorm`.

TypeORM v1.0.0 removes both symbols, including their type declarations. As a result, projects that upgrade `typeorm` to v1 while using `skipLibCheck: false` (the default in a plain `tsc` project — only flipped to `true` by the `@tsconfig/nodeXX` presets) get a type-check failure from inside `node_modules/@nestjs/typeorm`:

```
node_modules/@nestjs/typeorm/dist/common/typeorm.utils.d.ts: error TS2305:
  Module '"typeorm"' has no exported member 'AbstractRepository'.
node_modules/@nestjs/typeorm/dist/typeorm-core.module.d.ts: error TS2305:
  Module '"typeorm"' has no exported member 'Connection'.
```

This was flagged by @alumni in [this comment](https://github.com/nestjs/typeorm/issues/2556#issuecomment-2755012186) on the original issue.

Issue Number: #2556

## What is the new behavior?

Introduces a small `lib/common/typeorm-compat.ts` helper that resolves `Connection` and `AbstractRepository` through `require('typeorm')` at runtime:

- When TypeORM 0.3.x is installed, the constants resolve to the class, and the existing compat providers / `instanceof AbstractRepository` check continue to work unchanged.
- When TypeORM 1.0.x is installed, the constants resolve to `undefined`, the existing `if (Connection && ...)` / `AbstractRepository && ...` guards kick in, and the compat paths are skipped.

The static imports of these symbols from `typeorm` are dropped, so the compiled `.d.ts` files no longer reference them and consumers on TypeORM v1 can type-check cleanly regardless of `skipLibCheck`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Fully backwards-compatible with TypeORM 0.3.x. No user-facing API changes.

## Other information

- Verified `tsc -p tsconfig.json` compiles without errors.
- Manually verified that `require('./dist/common/typeorm-compat')` returns the real `Connection` / `AbstractRepository` classes when `typeorm@0.3.28` is installed.
- `getConnectionToken` and `InjectConnection` remain exported (only their underlying `Connection` *class* is now loaded lazily); no change for users of those deprecated aliases.