### PR TITLE
ci: use preinstalled docker compose in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
 
   integration_tests:
     working_directory: ~/nest
-    machine: true
+    machine:
+      image: ubuntu-2404:2026.05.1
     steps:
       - checkout
       - run:
@@ -50,18 +51,12 @@ jobs:
             node -v
             nvm alias default v24
       - run:
-          name: Install Docker Compose
-          command: |
-            curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > ~/docker-compose
-            chmod +x ~/docker-compose
-            sudo mv ~/docker-compose /usr/local/bin/docker-compose
-      - run:
           name: Install dependencies
           command: rm -f package-lock.json && npm install
       - run:
           name: Prepare
           command: |
-            docker-compose up -d
+            docker compose up -d
             sleep 10
       - run:
           name: List containers


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The CircleCI integration job downloads a Docker Compose binary from GitHub Releases with "curl", marks it executable, and installs it into "/usr/local/bin" without checksum, signature, or provenance verification.

Issue Number: #2623 


## What is the new behavior?

The integration job now uses an explicit CircleCI Linux VM image with Docker Compose preinstalled and runs services with "docker compose up -d". The workflow no longer downloads or executes a standalone Docker Compose binary during CI.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No