### PR TITLE
fix(deps): allow typeorm v1 in peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@nestjs/core": "^10.0.0 || ^11.0.0",
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
-        "typeorm": "^0.3.0"
+        "typeorm": "^0.3.0 || ^1.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@nestjs/core": "^10.0.0 || ^11.0.0",
     "reflect-metadata": "^0.1.13 || ^0.2.0",
     "rxjs": "^7.2.0",
-    "typeorm": "^0.3.0"
+    "typeorm": "^0.3.0 || ^1.0.0"
   },
   "lint-staged": {
     "**/*.{ts,json}": []


### PR DESCRIPTION
Follow-up to #2627.

TypeORM v1 support landed via the compat layer, but the `typeorm` peer dependency range was left at `^0.3.0`, so installing `@nestjs/typeorm` alongside the stable `typeorm@1.0.0` still fails peer resolution (as reported in the comments on #2627).

Widens the range to `^0.3.0 || ^1.0.0`. No code changes; lockfile refreshed accordingly.