### PR TITLE
feat(typeorm-core.module): inject providers into data source factory

### DIFF
--- a/lib/interfaces/typeorm-options.interface.ts
+++ b/lib/interfaces/typeorm-options.interface.ts
@@ -59,6 +59,7 @@ export interface TypeOrmOptionsFactory {
  */
 export type TypeOrmDataSourceFactory = (
   options?: DataSourceOptions,
+  ...injectedProviders: any[]
 ) => Promise<DataSource>;
 
 /**
@@ -76,5 +77,11 @@ export interface TypeOrmModuleAsyncOptions extends Pick<
   ) => Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions;
   dataSourceFactory?: TypeOrmDataSourceFactory;
   inject?: any[];
+  /**
+   * Providers to inject into `dataSourceFactory`, in addition to the
+   * resolved `TypeOrmModuleOptions` that is always passed as the first
+   * argument.
+   */
+  dataSourceFactoryInject?: any[];
   extraProviders?: Provider[];
 }

--- a/lib/typeorm-core.module.ts
+++ b/lib/typeorm-core.module.ts
@@ -83,9 +83,13 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
     if (options.name) {
       DataSourceNameRegistry.register(options.name);
     }
+    const dataSourceFactoryInject = options.dataSourceFactoryInject || [];
     const dataSourceProvider = {
       provide: getDataSourceToken(options as DataSourceOptions),
-      useFactory: async (typeOrmOptions: TypeOrmModuleOptions) => {
+      useFactory: async (
+        typeOrmOptions: TypeOrmModuleOptions,
+        ...injectedProviders: any[]
+      ) => {
         if (options.name) {
           return await this.createDataSourceFactory(
             {
@@ -93,14 +97,16 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
               name: options.name,
             },
             options.dataSourceFactory,
+            injectedProviders,
           );
         }
         return await this.createDataSourceFactory(
           typeOrmOptions,
           options.dataSourceFactory,
+          injectedProviders,
         );
       },
-      inject: [TYPEORM_MODULE_OPTIONS],
+      inject: [TYPEORM_MODULE_OPTIONS, ...dataSourceFactoryInject],
     };
     const entityManagerProvider = {
       provide: getEntityManagerToken(options as DataSourceOptions) as string,
@@ -206,17 +212,19 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
   private static async createDataSourceFactory(
     options: TypeOrmModuleOptions,
     dataSourceFactory?: TypeOrmDataSourceFactory,
+    injectedProviders: any[] = [],
   ): Promise<DataSource> {
     const dataSourceToken = getDataSourceName(options);
-    const createTypeormDataSource =
+    const createTypeormDataSource: TypeOrmDataSourceFactory =
       dataSourceFactory ??
-      ((options: DataSourceOptions) => new DataSource(options));
+      (async (options?: DataSourceOptions) => new DataSource(options!));
     return await lastValueFrom(
       defer(async () => {
         let dataSource: DataSource;
         if (!options.autoLoadEntities) {
           dataSource = await createTypeormDataSource(
             options as DataSourceOptions,
+            ...injectedProviders,
           );
         } else {
           let entities = options.entities;
@@ -228,10 +236,13 @@ export class TypeOrmCoreModule implements OnApplicationShutdown {
             entities =
               EntitiesMetadataStorage.getEntitiesByDataSource(dataSourceToken);
           }
-          dataSource = await createTypeormDataSource({
-            ...options,
-            entities,
-          } as DataSourceOptions);
+          dataSource = await createTypeormDataSource(
+            {
+              ...options,
+              entities,
+            } as DataSourceOptions,
+            ...injectedProviders,
+          );
         }
         return !dataSource.isInitialized && !options.manualInitialization
           ? dataSource.initialize()

--- a/tests/e2e/typeorm-async-data-source-factory-inject.spec.ts
+++ b/tests/e2e/typeorm-async-data-source-factory-inject.spec.ts
@@ -1,0 +1,39 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Server } from 'http';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { getDataSourceToken } from '../../lib';
+import { AsyncDataSourceFactoryInjectModule } from '../src/async-data-source-factory-inject.module';
+
+describe('TypeOrm (async configuration with dataSourceFactoryInject)', () => {
+  let server: Server;
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AsyncDataSourceFactoryInjectModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+  });
+
+  it('provides the injected dependency to `dataSourceFactory`', () => {
+    const dataSource = app.get<DataSource>(getDataSourceToken());
+    expect((dataSource.options as { applicationName?: string }).applicationName).toBe(
+      'nestjs-typeorm-e2e',
+    );
+  });
+
+  it(`should return created entity`, () => {
+    return request(server)
+      .post('/photo')
+      .expect(201, { name: 'Nest', description: 'Is great!', views: 6000 });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/tests/src/async-data-source-factory-inject.module.ts
+++ b/tests/src/async-data-source-factory-inject.module.ts
@@ -1,0 +1,51 @@
+import { Module } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { TypeOrmModule } from '../../lib';
+import { DataSourceExtrasService } from './data-source-extras.service';
+import { Photo } from './photo/photo.entity';
+import { PhotoModule } from './photo/photo.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRootAsync({
+      useFactory: () => ({
+        type: 'postgres',
+        host: '0.0.0.0',
+        port: 3306,
+        username: 'root',
+        password: 'root',
+        database: 'test',
+        entities: [Photo],
+        synchronize: true,
+        retryAttempts: 2,
+        retryDelay: 1000,
+      }),
+      dataSourceFactory: async (
+        options,
+        dataSourceExtrasService: DataSourceExtrasService,
+      ) => {
+        return new DataSource({
+          ...options!,
+          applicationName: dataSourceExtrasService.getApplicationName(),
+        });
+      },
+      dataSourceFactoryInject: [DataSourceExtrasService],
+      extraProviders: [DataSourceExtrasService],
+    }),
+    TypeOrmModule.forRoot({
+      name: 'connection_2',
+      type: 'postgres',
+      host: '0.0.0.0',
+      port: 3306,
+      username: 'root',
+      password: 'root',
+      database: 'test',
+      entities: [Photo],
+      synchronize: true,
+      retryAttempts: 2,
+      retryDelay: 1000,
+    }),
+    PhotoModule,
+  ],
+})
+export class AsyncDataSourceFactoryInjectModule {}

--- a/tests/src/data-source-extras.service.ts
+++ b/tests/src/data-source-extras.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DataSourceExtrasService {
+  getApplicationName(): string {
+    return 'nestjs-typeorm-e2e';
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] Other

## What is the current behavior?
`TypeOrmModuleAsyncOptions.dataSourceFactory` only ever receives the resolved
`DataSourceOptions`. There's no way to give it another DI-resolved provider
(e.g. a `ConfigService`), so the only workaround is instantiating dependencies
by hand inside the factory, bypassing Nest's DI container entirely.

Closes #1294

## What is the new behavior?
Adds a `dataSourceFactoryInject` option to `TypeOrmModuleAsyncOptions`,
mirroring the existing `inject` option for `useFactory`. Providers listed
there are resolved by Nest and passed to `dataSourceFactory` as additional
arguments after `options`:

```ts
TypeOrmModule.forRootAsync({
  useFactory: (config: ConfigService) => ({ ... }),
  inject: [ConfigService],
  dataSourceFactory: async (options, config: ConfigService) => {
    return new DataSource({ ...options, applicationName: config.get('APP_NAME') });
  },
  dataSourceFactoryInject: [ConfigService],
});
```

This continues the approach discussed in #1294 and started in #2517, reimplemented
against current `master` (that PR had drifted out of sync and had no CI/review
activity since February).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

`dataSourceFactoryInject` defaults to an empty array, so existing
`dataSourceFactory` usages are unaffected.

## Other information
Verified locally: `tsc --noEmit`, `oxlint`, and the full e2e suite
(`npm run test:e2e`) pass — 10 test files / 17 tests, including two new tests
that boot a real Postgres-backed `DataSource` built from a provider injected
via `dataSourceFactoryInject` and exercise it through an HTTP request.
