### PR TITLE
fix: add default condition to exports so CJS can resolve the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## What is the current behavior?

`@nestjs/typeorm@12.0.0` cannot be loaded from CommonJS. `require('@nestjs/typeorm')` throws:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
  /.../node_modules/@nestjs/typeorm/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:605:13)
    at resolveExports (node:internal/modules/cjs/loader:707:36)
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
```

The `exports` map added in 36a765c1 declares only `types` and `import`:

```jsonc
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js"
  },
  "./package.json": "./package.json"
}
```

Node resolves `require()` under the `require` condition and falls back to `default`. Neither exists here, so resolution fails before `require(esm)` can load the module, and `"main"` is not consulted because `"exports"` takes precedence.

This contradicts the v12.0.0 release notes, which say CJS consumers do not need to migrate:

> **You do not need to convert your app to ESM.** Thanks to Node's `require(esm)` support, CJS apps still work.

It also breaks the default `nest new` project, which compiles to CommonJS.

Issue: #2684

## What is the new behavior?

`require('@nestjs/typeorm')` resolves and loads through `require(esm)` on Node >= 20.19.0. ESM consumers are unaffected — the `import` condition still matches first and points at the same file.

`default` rather than `require` keeps this consistent with the sibling v12 packages, which all expose a CJS-resolvable condition:

| Package | `type` | Conditions under `"."` | `require()` |
| --- | --- | --- | --- |
| `@nestjs/common@12.0.1` | module | `"./index.js"` (string) | ok |
| `@nestjs/core@12.0.1` | module | `"./index.js"` (string) | ok |
| `@nestjs/config@12.0.0` | module | types, import, default | ok |
| `@nestjs/mongoose@12.0.0` | module | types, default | ok |
| `@nestjs/passport@12.0.0` | module | types, default | ok |
| `@nestjs/swagger@12.0.0` | module | types, import, default, require | ok |
| `@nestjs/schedule@12.0.1` | module | types, default | ok |
| `@nestjs/axios@12.0.0` | module | types, default | ok |
| `@nestjs/event-emitter@12.0.0` | module | types, default | ok |
| `@nestjs/cache-manager@12.0.0` | module | types, import, default, require | ok |
| `@nestjs/bullmq@12.0.0` | module | types, import, require | ok |
| `@nestjs/jwt@12.0.1` | module | types, import, default | ok |
| `@nestjs/graphql@14.0.0` | module | node, types, import, browser, default, require, react-native | ok |
| `@nestjs/typeorm@12.0.0` | module | **types, import** | **ERR_PACKAGE_PATH_NOT_EXPORTED** |

Installed side by side in one tree and required on Node v24.18.1 — every one of these is `"type": "module"`, so the ESM build is not what separates them:

```
OK     @nestjs/common       114 exports
OK     @nestjs/core          31 exports
OK     @nestjs/config         6 exports
OK     @nestjs/mongoose      15 exports
FAIL   @nestjs/typeorm       ERR_PACKAGE_PATH_NOT_EXPORTED
```

The only difference is the condition map.

Verified on Node v24.18.1 against the published `12.0.0` tarball with the patch applied:

```shell
node -e "require('@nestjs/typeorm')"                                  # was: ERR_PACKAGE_PATH_NOT_EXPORTED -> now: ok
node --input-type=module -e "import('@nestjs/typeorm')"               # ok (unchanged)
```

Both entry points resolve to `./dist/index.js` and expose the same 15 named exports.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

The change is limited to the `exports` map; no build or source changes. `master` is still on the broken map as of 5ccaea43 and `12.0.1` is unpublished, so this can ship with that release.
