### PR TITLE
fix(common): throw when EntitySchema has no target or name in getRepositoryToken

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -58,9 +58,15 @@ export function getRepositoryToken(
   }
 
   if (entity instanceof EntitySchema) {
-    return `${dataSourcePrefix}${
-      entity.options.target ? entity.options.target.name : entity.options.name
-    }Repository`;
+    const schemaName = entity.options.target
+      ? entity.options.target.name
+      : entity.options.name;
+    if (!schemaName) {
+      throw new Error(
+        'EntitySchema must have either "target" or "name" defined',
+      );
+    }
+    return `${dataSourcePrefix}${schemaName}Repository`;
   }
   return `${dataSourcePrefix}${entity.name}Repository`;
 }

--- a/tests/unit/typeorm-utils.spec.ts
+++ b/tests/unit/typeorm-utils.spec.ts
@@ -1,0 +1,34 @@
+import { EntitySchema } from 'typeorm';
+import { getRepositoryToken } from '../../lib';
+
+describe('getRepositoryToken (EntitySchema)', () => {
+  it('uses options.target.name when target is set', () => {
+    class Photo {}
+    const schema = new EntitySchema<Photo>({
+      name: 'photo_ignored_when_target_present',
+      target: Photo,
+      columns: {},
+    });
+
+    expect(getRepositoryToken(schema)).toBe('PhotoRepository');
+  });
+
+  it('uses options.name when target is not set', () => {
+    const schema = new EntitySchema({
+      name: 'Photo',
+      columns: {},
+    });
+
+    expect(getRepositoryToken(schema)).toBe('PhotoRepository');
+  });
+
+  it('throws when neither target nor name is defined', () => {
+    const schema = new EntitySchema({
+      columns: {},
+    } as ConstructorParameters<typeof EntitySchema>[0]);
+
+    expect(() => getRepositoryToken(schema)).toThrow(
+      'EntitySchema must have either "target" or "name" defined',
+    );
+  });
+});


### PR DESCRIPTION
Closes #2686

`getRepositoryToken()` silently produced `"undefinedRepository"` 
when an `EntitySchema` had neither `options.target` nor `options.name` 
set. Two branches earlier, a `null`/`undefined` entity already throws 
`CircularDependencyException` — this is the same class of 
misconfiguration but was handled inconsistently.

Fix: validate `schemaName` before building the token string and 
throw a clear `Error` if neither field is set.