### PR TITLE
fix(common): throw error when EntitySchema lacks target and name

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -38,9 +38,7 @@ function getName(
 export function getRepositoryToken(
   entity: EntityClassOrSchema,
   dataSource:
-    | DataSource
-    | DataSourceOptions
-    | string = DEFAULT_DATA_SOURCE_NAME,
+    DataSource | DataSourceOptions | string = DEFAULT_DATA_SOURCE_NAME,
 ): Function | string {
   if (entity === null || entity === undefined) {
     throw new CircularDependencyException('@InjectRepository()');
@@ -58,9 +56,13 @@ export function getRepositoryToken(
   }
 
   if (entity instanceof EntitySchema) {
-    return `${dataSourcePrefix}${
-      entity.options.target ? entity.options.target.name : entity.options.name
-    }Repository`;
+    const schemaName = entity.options.target
+      ? entity.options.target.name
+      : entity.options.name;
+    if (!schemaName) {
+      throw new Error('EntitySchema must define either "target" or "name"');
+    }
+    return `${dataSourcePrefix}${schemaName}Repository`;
   }
   return `${dataSourcePrefix}${entity.name}Repository`;
 }
@@ -89,9 +91,7 @@ export function getCustomRepositoryToken(repository: Function): string {
  */
 export function getDataSourceToken(
   dataSource:
-    | DataSource
-    | DataSourceOptions
-    | string = DEFAULT_DATA_SOURCE_NAME,
+    DataSource | DataSourceOptions | string = DEFAULT_DATA_SOURCE_NAME,
 ): string | Function | Type<DataSource> {
   return DEFAULT_DATA_SOURCE_NAME === dataSource
     ? DataSource
@@ -117,9 +117,7 @@ export const getConnectionToken = getDataSourceToken;
  */
 export function getDataSourcePrefix(
   dataSource:
-    | DataSource
-    | DataSourceOptions
-    | string = DEFAULT_DATA_SOURCE_NAME,
+    DataSource | DataSourceOptions | string = DEFAULT_DATA_SOURCE_NAME,
 ): string {
   if (dataSource === DEFAULT_DATA_SOURCE_NAME) {
     return '';
@@ -142,9 +140,7 @@ export function getDataSourcePrefix(
  */
 export function getEntityManagerToken(
   dataSource:
-    | DataSource
-    | DataSourceOptions
-    | string = DEFAULT_DATA_SOURCE_NAME,
+    DataSource | DataSourceOptions | string = DEFAULT_DATA_SOURCE_NAME,
 ): string | Function {
   return DEFAULT_DATA_SOURCE_NAME === dataSource
     ? EntityManager

--- a/tests/common/typeorm.utils.spec.ts
+++ b/tests/common/typeorm.utils.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { EntitySchema, Repository } from 'typeorm';
+import {
+  getCustomRepositoryToken,
+  getDataSourceName,
+  getDataSourcePrefix,
+  getDataSourceToken,
+  getEntityManagerToken,
+  getRepositoryToken,
+} from '../../lib/common/typeorm.utils.js';
+import { CircularDependencyException } from '../../lib/exceptions/circular-dependency.exception.js';
+import { DEFAULT_DATA_SOURCE_NAME } from '../../lib/typeorm.constants.js';
+
+describe('typeorm.utils', () => {
+  describe('getRepositoryToken', () => {
+    class TestEntity {}
+
+    class CustomRepository extends Repository<TestEntity> {}
+
+    it('should return entity repository token for a class', () => {
+      expect(getRepositoryToken(TestEntity)).toBe('TestEntityRepository');
+    });
+
+    it('should prefix token with dataSource name when provided as string', () => {
+      expect(getRepositoryToken(TestEntity, 'tenant1')).toBe(
+        'tenant1_TestEntityRepository',
+      );
+    });
+
+    it('should prefix token with dataSource name when provided as DataSourceOptions object', () => {
+      expect(getRepositoryToken(TestEntity, { name: 'analytics' } as any)).toBe(
+        'analytics_TestEntityRepository',
+      );
+    });
+
+    it('should return entity repository token for an EntitySchema with name', () => {
+      const schema = new EntitySchema({
+        name: 'UserSchema',
+        columns: {},
+      });
+      expect(getRepositoryToken(schema)).toBe('UserSchemaRepository');
+    });
+
+    it('should return entity repository token for an EntitySchema with target', () => {
+      class TargetEntity {}
+      const schema = new EntitySchema({
+        name: 'IgnoredName',
+        target: TargetEntity,
+        columns: {},
+      });
+      expect(getRepositoryToken(schema)).toBe('TargetEntityRepository');
+    });
+
+    it('should return custom repository directly if no prefix', () => {
+      expect(getRepositoryToken(CustomRepository)).toBe(CustomRepository);
+    });
+
+    it('should prefix custom repository token when dataSource prefix is present', () => {
+      expect(getRepositoryToken(CustomRepository, 'custom')).toBe(
+        'custom_CustomRepository',
+      );
+    });
+
+    it('should throw CircularDependencyException when entity is null or undefined', () => {
+      expect(() => getRepositoryToken(null as any)).toThrow(
+        CircularDependencyException,
+      );
+      expect(() => getRepositoryToken(undefined as any)).toThrow(
+        CircularDependencyException,
+      );
+    });
+
+    it('should throw an error when EntitySchema does not define target or name', () => {
+      const schemaWithoutNameOrTarget = new EntitySchema({
+        columns: {},
+      } as any);
+
+      expect(() => getRepositoryToken(schemaWithoutNameOrTarget)).toThrow(
+        'EntitySchema must define either "target" or "name"',
+      );
+    });
+  });
+
+  describe('getCustomRepositoryToken', () => {
+    class CustomRepo {}
+
+    it('should return repository name', () => {
+      expect(getCustomRepositoryToken(CustomRepo)).toBe('CustomRepo');
+    });
+
+    it('should throw CircularDependencyException when repository is null or undefined', () => {
+      expect(() => getCustomRepositoryToken(null as any)).toThrow(
+        CircularDependencyException,
+      );
+      expect(() => getCustomRepositoryToken(undefined as any)).toThrow(
+        CircularDependencyException,
+      );
+    });
+  });
+
+  describe('getDataSourceToken', () => {
+    it('should return DataSource class for default dataSource', () => {
+      expect(getDataSourceToken()).toBeDefined();
+      expect(getDataSourceToken(DEFAULT_DATA_SOURCE_NAME)).toBeDefined();
+    });
+
+    it('should return formatted token for string dataSource name', () => {
+      expect(getDataSourceToken('custom')).toBe('customDataSource');
+    });
+  });
+
+  describe('getEntityManagerToken', () => {
+    it('should return EntityManager class for default dataSource', () => {
+      expect(getEntityManagerToken()).toBeDefined();
+    });
+
+    it('should return formatted token for string dataSource name', () => {
+      expect(getEntityManagerToken('custom')).toBe('customEntityManager');
+    });
+  });
+
+  describe('getDataSourcePrefix', () => {
+    it('should return empty string for default dataSource', () => {
+      expect(getDataSourcePrefix()).toBe('');
+      expect(getDataSourcePrefix(DEFAULT_DATA_SOURCE_NAME)).toBe('');
+    });
+
+    it('should return prefixed string for custom dataSource', () => {
+      expect(getDataSourcePrefix('custom')).toBe('custom_');
+    });
+  });
+
+  describe('getDataSourceName', () => {
+    it('should return default name when options name is not provided', () => {
+      expect(getDataSourceName({} as any)).toBe(DEFAULT_DATA_SOURCE_NAME);
+    });
+
+    it('should return name when options has name', () => {
+      expect(getDataSourceName({ name: 'my_db' })).toBe('my_db');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When an `EntitySchema` is provided that has neither `options.target` nor `options.name` defined, `getRepositoryToken()` silently formats the token as `${dataSourcePrefix}undefinedRepository` instead of throwing an error.

Issue Number: #2686


## What is the new behavior?

`getRepositoryToken()` now checks that `schemaName` exists (derived from `options.target.name` or `options.name`). If neither is defined, it throws an `Error('EntitySchema must define either "target" or "name"')`, consistent with other misconfiguration checks in the same utility function.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Includes unit tests in `tests/common/typeorm.utils.spec.ts` covering `getRepositoryToken` edge cases as well as `getCustomRepositoryToken`, `getDataSourceToken`, `getEntityManagerToken`, and `getDataSourcePrefix`.
